### PR TITLE
Volume change SDL

### DIFF
--- a/src/client/main-sdl.c
+++ b/src/client/main-sdl.c
@@ -1601,11 +1601,13 @@ static void FontSizeChange(sdl_Button *sender)
 }
 
 
-static void VolumeChange(sdl_Button *sender)
-{
-    volume += sender->tag;
-    volume = set_volume(volume);
-}
+#ifdef SOUND_SDL
+    static void VolumeChange(sdl_Button *sender)
+    {
+        volume += sender->tag;
+        volume = set_volume(volume);
+    }
+#endif
 
 
 static void MoreDraw(sdl_Window *win)

--- a/src/client/snd-sdl.c
+++ b/src/client/snd-sdl.c
@@ -65,6 +65,22 @@ typedef struct
 static bool use_init = false;
 
 
+struct sound_config* get_sound_config() {
+    static struct sound_config config;
+    return &config;
+}
+
+
+int set_volume(int volume) {
+    if (volume < 0) volume = 0;
+    if (volume > 100) volume = 100;
+
+    /* Set all channels to volume */
+    Mix_Volume(-1, (volume * MIX_MAX_VOLUME) / 100);
+    return volume;
+}
+
+
 /*
  * Initialize SDL and open the mixer.
  */
@@ -73,12 +89,14 @@ static bool open_audio_sdl(void)
     int audio_rate;
     Uint16 audio_format;
     int audio_channels;
+    int volume;
 
     /* Initialize variables */
     audio_rate = 22050;
     audio_format = AUDIO_S16;
     audio_channels = 2;
-
+    volume = get_sound_config()->volume;
+    
     /* Initialize the SDL library */
     if (SDL_Init(SDL_INIT_AUDIO) < 0)
     {
@@ -92,6 +110,9 @@ static bool open_audio_sdl(void)
         plog_fmt("Couldn't open mixer: %s", SDL_GetError());
         return false;
     }
+
+    /* Set initial volume */
+    set_volume(volume);
 
     /* Success */
     return true;
@@ -283,4 +304,4 @@ errr init_sound_sdl(struct sound_hooks *hooks)
 }
 
 
-#endif /* USE_SDL */
+#endif /* USE_SDL */

--- a/src/client/snd-win.c
+++ b/src/client/snd-win.c
@@ -49,6 +49,17 @@ typedef struct
 } win_sample;
 
 
+struct sound_config* get_sound_config() {
+    // Not used 
+    return NULL;
+}
+
+
+int set_volume(int volume) {
+    return volume;
+}
+
+
 static bool open_audio_win(void)
 {
     return true;

--- a/src/client/sound.h
+++ b/src/client/sound.h
@@ -45,7 +45,23 @@ struct sound_hooks
     bool (*play_sound_hook)(struct sound_data *data);
 };
 
+struct sound_config
+{
+    int volume;
+};
+
 extern errr init_sound(void);
 extern errr register_sound_pref_parser(struct parser *p);
+
+/*
+ * Return static variable of sound config
+ */
+extern struct sound_config* get_sound_config(void);
+
+/*
+ * Set volume in %
+ * Return actually volume % was set
+ */
+extern int set_volume(int);
 
 #endif /* INCLUDED_SOUND_H */


### PR DESCRIPTION
I added an ability to change the volume in options in the game (in percents). This is a useful feature when you don't need to set up the system mixer. It works only with SDL. The set volume is saved in sdlinit.txt with a key Volume. I took care that this doesn't cause problems for clients without SDL. I tested it only on Linux, but it should work anywhere. If there are any problems, I'll fix that.

A slight implementation complication is that the user settings file is read in the graphics system, but it loads before the sound. Therefore, you cannot immediately set the mixer value. To initialize the volume I use the global variable that can be obtained from the get_sound_config function declared in the sound.h header. When the sound system is loaded, it reads this value and sets the volume in SDL mixer. Perhaps this is not the best design, but I couldn't find a more suitable and simple solution.