### PR TITLE
Update main-sdl2.c

### DIFF
--- a/src/client/main-sdl2.c
+++ b/src/client/main-sdl2.c
@@ -1018,10 +1018,8 @@ static void render_tile_font_scaled(const struct subwindow *subwindow,
     SDL_Rect dst = {
         subwindow->inner_rect.x + col * subwindow->font_width,
         subwindow->inner_rect.y + row * subwindow->font_height,
-        subwindow->font_width * (subwindow->index == MAIN_SUBWINDOW && 
-            !Term->minimap_active ? tile_width : 1),
-        subwindow->font_height * (subwindow->index == MAIN_SUBWINDOW && 
-            !Term->minimap_active ? tile_height : 1)
+        subwindow->font_width * (!Term->minimap_active ? tile_width : 1),
+        subwindow->font_height * (!Term->minimap_active ? tile_height : 1)
     };
 
     if (fill) {
@@ -4332,6 +4330,9 @@ static void load_graphics(struct window *window, graphics_mode *mode)
 
         window->graphics.overdraw_row = mode->overdrawRow;
         window->graphics.overdraw_max = mode->overdrawMax;
+
+        /* Use ASCII symbol for distorted tiles */
+        tile_distorted = is_tile_distorted(use_graphics, tile_width, tile_height);
     }
 
     if (Setup.initialized) {
@@ -5692,8 +5693,8 @@ static void init_colors(void)
     }
     for (i = 0; i < N_ELEMENTS(g_windows); i++)
         g_windows[i].color = g_colors[DEFAULT_WINDOW_BG_COLOR];
-    for (i = 0; i < N_ELEMENTS(g_subwindows); i++)
-        g_subwindows[i].color = g_colors[DEFAULT_SUBWINDOW_BG_COLOR];
+/*  for (i = 0; i < N_ELEMENTS(g_subwindows); i++) */
+/*      g_subwindows[i].color = g_colors[DEFAULT_SUBWINDOW_BG_COLOR]; */
 }
 
 static void init_font_info(const char *directory)

--- a/src/common/h-basic.h
+++ b/src/common/h-basic.h
@@ -111,7 +111,6 @@
 /* Version number of package */
 #define VERSION ""
 /*
-#include <SDL.h>
 #include <android/log.h>
 #define LOGV(...) __android_log_print(ANDROID_LOG_VERBOSE, "PWMAngband", __VA_ARGS__)
 #define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG  , "PWMAngband", __VA_ARGS__)


### PR DESCRIPTION
- tile_distorted - Use ASCII symbol for distorted tiles (main-sdl.c, main-win.c)
- workaround fix for g_subwindows alpha init_colors()

in file 'dblh_hook' from V but something doesn't work
```
src/client/main-sdl2.c
if (subwindow->window->graphics.overdraw_row) {
    subwindow->term->dblh_hook = is_dh_tile;
} else {
    subwindow->term->dblh_hook = NULL;
}
src/client/ui-term.c
Term_fresh_row_pict_dblh()
PW_OVERHEAD /* Display overhead view */
```
VVVVV
[PWMAngband-dblh_hook.zip](https://github.com/draconisPW/PWMAngband/files/8094959/PWMAngband-dblh_hook.zip)

