### PR TITLE
Update Android client

### DIFF
--- a/src/android/gradle.properties
+++ b/src/android/gradle.properties
@@ -15,3 +15,10 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+# Automatically convert third-party libraries to use AndroidX
+android.enableJetifier=true

--- a/src/android/pwmangclient/build.gradle
+++ b/src/android/pwmangclient/build.gradle
@@ -8,13 +8,13 @@ else {
 }
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     defaultConfig {
         if (buildAsApplication) {
             applicationId "org.pwmangband.pwmangclient"
         }
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         externalNativeBuild {
@@ -68,4 +68,5 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation 'androidx.appcompat:appcompat:1.1.0'
 }

--- a/src/android/pwmangclient/src/main/java/org/pwmangband/pwmangclient/PWMAngClient.java
+++ b/src/android/pwmangclient/src/main/java/org/pwmangband/pwmangclient/PWMAngClient.java
@@ -1,14 +1,64 @@
 package org.pwmangband.pwmangclient;
 
+import android.Manifest;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
+
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 
 import org.libsdl.app.SDLActivity;
 
 public class PWMAngClient extends SDLActivity {
+    /** State of requested permissions. */
+    private enum PermissionState {
+        UNKNOWN,
+        REQUESTED,
+        GRANTED,
+        DENIED
+    }
+    /** State of WRITE_EXTERNAL_STORAGE permission. */
+    private PermissionState storagePermission = PermissionState.UNKNOWN;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Settings.setEnvVars();
+        checkPermission();
+        if (!storageAvailable()) finish();
+    }
+
+    /** Create directory structure on SD card. */
+    private void checkPermission() {
+        if (storagePermission == PermissionState.UNKNOWN) {
+            String extStorage = Manifest.permission.WRITE_EXTERNAL_STORAGE;
+            if (ContextCompat.checkSelfPermission(this, extStorage) ==
+                    PackageManager.PERMISSION_GRANTED) {
+                storagePermission = PermissionState.GRANTED;
+            } else {
+                storagePermission = PermissionState.REQUESTED;
+                ActivityCompat.requestPermissions(this, new String[]{extStorage}, 0);
+            }
+        }
+        if (storagePermission != PermissionState.GRANTED)
+            return;
+
         Settings.checkInstall(getApplicationContext());
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int code, String[] permissions, int[] results) {
+        if (storagePermission == PermissionState.REQUESTED) {
+            if ((results.length > 0) && (results[0] == PackageManager.PERMISSION_GRANTED))
+                storagePermission = PermissionState.GRANTED;
+            else
+                storagePermission = PermissionState.DENIED;
+        }
+        checkPermission();
+    }
+
+    /** Return true if the WRITE_EXTERNAL_STORAGE permission has been granted. */
+    private boolean storageAvailable() {
+        return storagePermission == PermissionState.GRANTED;
     }
 }

--- a/src/android/pwmangclient/src/main/java/org/pwmangband/pwmangclient/Settings.java
+++ b/src/android/pwmangclient/src/main/java/org/pwmangband/pwmangclient/Settings.java
@@ -17,37 +17,46 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 public class Settings extends PWMAngClient {
+    public static final String angDir = "PWMAngband";
+
+    public static boolean ToastAngDir, ToastAngIni, ToastAngLib;
+
     public static void setEnvVars() {
-        SDLActivity.nativeSetenv("HOME", Environment.getExternalStorageDirectory().getAbsolutePath() + "/pwmangclient");
-        SDLActivity.nativeSetenv("ANDROID_APP_PATH", Environment.getExternalStorageDirectory().getAbsolutePath() + "/pwmangclient");
+        SDLActivity.nativeSetenv("HOME", Environment.getExternalStorageDirectory().getAbsolutePath() + File.separator + angDir);
+        SDLActivity.nativeSetenv("ANDROID_APP_PATH", Environment.getExternalStorageDirectory().getAbsolutePath() + File.separator + angDir);
     }
 
     public static void checkInstall(Context context) {
-        File folder = new File(Environment.getExternalStorageDirectory() + File.separator + "pwmangclient");
+        File folder = new File(Environment.getExternalStorageDirectory() + File.separator + angDir);
         if (!folder.exists()) {
-            Log.i("Not Found Dir", "Creating directory 'pwmangclient'");
-            createNewDirectory("pwmangclient");
+            Log.i("Not Found Dir", "Creating directory " + File.separator + angDir);
+            ToastAngDir = true;
+            createNewDirectory(angDir);
         } else {
-            Log.i("Found Dir", "directory 'pwmangclient'" );
+            Log.i("Found Dir", "directory " + File.separator + angDir);
         }
 
-        File file = new File(Environment.getExternalStorageDirectory() + File.separator + "pwmangclient/pwmangclient.ini");
+        File file = new File(Environment.getExternalStorageDirectory() + File.separator + angDir + "/pwmangclient.ini");
         if (!file.exists()) {
             Log.i("File Not Found", "Copy assets file 'pwmangclient.ini'");
-            Toast.makeText(context,"assets file 'pwmangclient.ini'", Toast.LENGTH_LONG).show();
-            copyAssets(context, "pwmangclient.ini", "/pwmangclient");
+            ToastAngIni = true;
+            copyAssets(context, "pwmangclient.ini", File.separator + angDir);
         } else {
             Log.i("File Found", "file 'pwmangclient.ini'" );
         }
 
-        File folder_lib = new File(Environment.getExternalStorageDirectory() + File.separator + "pwmangclient/lib");
+        File folder_lib = new File(Environment.getExternalStorageDirectory() + File.separator + angDir + "/lib");
         if (!folder_lib.exists()) {
             Log.i("Not Found Dir", "Copy assets files 'lib'");
-            unZip(context, "lib.zip", "/pwmangclient", true);
-            Toast.makeText(context,"assets files 'lib'", Toast.LENGTH_LONG).show();
+            ToastAngLib = true;
+            unZip(context, "lib.zip", File.separator + angDir, true);
         } else {
             Log.i("Found Dir", "directory 'lib'" );
         }
+
+        if (ToastAngDir) Toast.makeText(context,"Creating directory " + File.separator + angDir, Toast.LENGTH_LONG).show();
+        if (ToastAngIni) Toast.makeText(context,"assets file 'pwmangclient.ini'", Toast.LENGTH_LONG).show();
+        if (ToastAngLib) Toast.makeText(context,"assets files 'lib'", Toast.LENGTH_LONG).show();
     }
 
     public static void createNewDirectory(String name) {

--- a/src/android/readme.txt
+++ b/src/android/readme.txt
@@ -30,4 +30,12 @@ Prepare gradle
 Download and install Android Studio.
 https://developer.android.com/studio
 
-TODO
+Run it, select 'Open existing project' and navigate to pwmangband src/android directory.
+
+Android Studio will prompt you to download lots of stuff, android SDK, NDK, platform-tools, etc, and will ask to accept several EULAs. Do it.
+
+Note: Android Studio will also ask if you want to add some of the newly generated files to git. Don't!
+
+After all is done, both build and run buttons should work! That's it.
+
+You can also build from command line, by running ./gradlew build (or gradlew.bat, on Windows), but you will need to prepare some environmental variables, like JAVA_HOME and ANDROID_HOME, to do so.


### PR DESCRIPTION
- AndroidX, compileSdkVersion 28
https://developer.android.com/jetpack/androidx

_java code dependencies:_
```
/src/android/pwmangclient/build.gradle
dependencies {
    implementation 'androidx.appcompat:appcompat:1.1.0'
}
```

_in compileSdkVersion 30 - 31 may be warnings:_
Manifest merger failed : android:exported needs to be explicitly specified for element <activity#org.pwmangband.pwmangclient.PWMAngClient>. Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.
android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
https://stackoverflow.com/questions/68140893/android-studio-throwing-ioexception-operation-not-permitted
compileSdkVersion 28, targetSdkVersion 28 _works correctly._

- angDir = "PWMAngband";
- android/readme.txt
- checkPermission() Create directory structure on SD card. 
from https://github.com/peterosterlund2/droidfish/blob/master/DroidFishApp/src/main/java/org/petero/droidfish/DroidFish.java  

- Toast messages are displayed in turn, when main window SDL2 is running

_when I click 'Make Project' it downloads automatically_
  Preparing "Install NDK (Side by side) 21.4.7075529 (revision: 21.4.7075529)".
  Preparing "Install Android SDK Build-Tools 30.0.3 (revision: 30.0.3)".
_tested on Android 12(API 31), Android 11, Android 4.4 client is running_

window 'Allow' appears but without wait `if (!storageAvailable()) finish();` 
client closes and needs to be restarted with SD card access allowed.
![pwm-image](https://user-images.githubusercontent.com/71586060/158018988-242c5efc-59d4-47bb-9275-f36fea2b0cb7.png)

