### PR TITLE
Update main-sdl2.c

### DIFF
--- a/src/client/main-sdl2.c
+++ b/src/client/main-sdl2.c
@@ -87,7 +87,6 @@
     (DEFAULT_BORDER * 2)
 #define DEFAULT_VISIBLE_BORDER 2
 
-#define DEFAULT_FONT_SIZE 0
 /* XXX hack: the widest character present in a font
  * for determining font advance (width) */
 #define GLYPH_FOR_ADVANCE 'W'
@@ -98,8 +97,6 @@
 #define DEFAULT_FONT_H 20
 
 #define DEFAULT_STATUS_BAR_FONT "8x13x.fon"
-#define DEFAULT_STATUS_BAR_FONT_W 8
-#define DEFAULT_STATUS_BAR_FONT_H 13
 
 #define MAX_VECTOR_FONT_SIZE 36
 #define MIN_VECTOR_FONT_SIZE 4
@@ -1123,13 +1120,13 @@ static SDL_Texture *make_subwindow_texture(const struct window *window, int w, i
     SDL_Texture *texture = SDL_CreateTexture(window->renderer,
             window->pixelformat, SDL_TEXTUREACCESS_TARGET, w, h);
     if (texture == NULL) {
-        quit_fmt("cant create texture for subwindow in window %u: %s",
+        quit_fmt("cannot create texture for subwindow in window %u: %s",
                 window->index, SDL_GetError());
     }
 
     if (SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND) != 0) {
         SDL_DestroyTexture(texture);
-        quit_fmt("cant set blend mode for texture in window %u: %s",
+        quit_fmt("cannot set blend mode for texture in window %u: %s",
                 window->index, SDL_GetError());
     }
 
@@ -2203,6 +2200,7 @@ static void handle_menu_tile_sets(struct window *window,
     }
 
     size_t num_elems = 0;
+    struct menu_elem *elems;
 
     graphics_mode *mode = graphics_modes;
     while (mode != NULL) {
@@ -2210,7 +2208,7 @@ static void handle_menu_tile_sets(struct window *window,
         mode = mode->pNext;
     }
 
-    struct menu_elem elems[num_elems];
+    elems = mem_alloc(num_elems * sizeof(*elems));
 
     mode = graphics_modes;
     for (size_t i = 0; i < num_elems; i++) {
@@ -2224,6 +2222,8 @@ static void handle_menu_tile_sets(struct window *window,
     }
 
     load_next_menu_panel(window, menu_panel, button, num_elems, elems);
+
+    mem_free(elems);
 }
 
 static void handle_menu_tiles(struct window *window,
@@ -4203,9 +4203,9 @@ static void term_view_map_text(struct subwindow *subwindow)
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0");
 }
 
-static void term_view_map_hook(term *term)
+static void term_view_map_hook(term *terminal)
 {
-    struct subwindow *subwindow = term->data;
+    struct subwindow *subwindow = terminal->data;
 
     subwindow->term->view_map_hook = NULL;
     /* do_cmd_view_map(); waiting for a keypress inkey_ex();*/
@@ -4223,11 +4223,11 @@ static SDL_Texture *load_image(const struct window *window, const char *path)
 {
     SDL_Surface *surface = IMG_Load(path);
     if (surface == NULL) {
-        quit_fmt("cant load image '%s': %s", path, IMG_GetError());
+        quit_fmt("cannot load image '%s': %s", path, IMG_GetError());
     }
     SDL_Texture *texture = SDL_CreateTextureFromSurface(window->renderer, surface);
     if (texture == NULL) {
-        quit_fmt("cant create texture from image '%s': %s", path, SDL_GetError());
+        quit_fmt("cannot create texture from image '%s': %s", path, SDL_GetError());
     }
     SDL_FreeSurface(surface);
 
@@ -4316,11 +4316,12 @@ static void load_graphics(struct window *window, graphics_mode *mode)
     if (use_graphics == GRAPHICS_NONE) {
         tile_width = 1;
         tile_height = 1;
+        tile_distorted = false;
     } else {
         char path[4096];
         path_build(path, sizeof(path), mode->path, mode->file);
         if (!file_exists(path)) {
-            quit_fmt("cant load graphcis: file '%s' doesnt exist", path);
+            quit_fmt("cannot load graphics: file '%s' doesnt exist", path);
         }
 
         window->graphics.texture = load_image(window, path);
@@ -4399,7 +4400,7 @@ static void make_font_cache(const struct window *window, struct font *font)
 
         SDL_Texture *texture = SDL_CreateTextureFromSurface(window->renderer, surface);
         if (texture == NULL)
-            quit_fmt("cant create texture for cache in font '%s': %s", font->name, SDL_GetError());
+            quit_fmt("cannot create texture for cache in font '%s': %s", font->name, SDL_GetError());
 
         SDL_Rect src = {0, 0, surface->w, surface->h};
         SDL_Rect dst = {glyph_w * i, 0, glyph_w, glyph_h};
@@ -4483,7 +4484,7 @@ static void load_font(struct font *font)
 
     font->ttf.handle = TTF_OpenFont(font->path, font->size);
     if (font->ttf.handle == NULL) {
-        quit_fmt("cant open font '%s': %s", font->path, TTF_GetError());
+        quit_fmt("cannot open font '%s': %s", font->path, TTF_GetError());
     }
 
     font->ttf.glyph.h = TTF_FontHeight(font->ttf.handle);
@@ -4491,7 +4492,7 @@ static void load_font(struct font *font)
     if (TTF_GlyphMetrics(font->ttf.handle, GLYPH_FOR_ADVANCE,
                 NULL, NULL, NULL, NULL, &font->ttf.glyph.w) != 0)
     {
-        quit_fmt("cant query glyph metrics for font '%s': %s",
+        quit_fmt("cannot query glyph metrics for font '%s': %s",
                 font->path, TTF_GetError());
     }
 
@@ -4750,6 +4751,10 @@ static bool handle_button_open_subwindow(struct window *window,
         subwindow = make_subwindow(window, index);
         assert(subwindow != NULL);
         bring_to_top(window, subwindow);
+        /* Reinitialize all subwindows */
+        subwindows_reinit_flags();
+        /* Set up the subwindows */
+        subwindows_init_flags();
         refresh_angband_terms();
     }
 
@@ -4877,17 +4882,17 @@ static void load_status_bar(struct window *window)
     if (SDL_SetRenderDrawColor(window->renderer,
                 window->status_bar.color.r, window->status_bar.color.g,
                 window->status_bar.color.b, window->status_bar.color.a) != 0) {
-        quit_fmt("cant set render color for status bar in window %u: %s",
+        quit_fmt("cannot set render color for status bar in window %u: %s",
                 window->index, SDL_GetError());
     }
     /* well, renderer seems to work */
     if (SDL_SetRenderTarget(window->renderer, window->status_bar.texture) != 0) {
-        quit_fmt("cant set status bar texture as target in window %u: %s",
+        quit_fmt("cannot set status bar texture as target in window %u: %s",
                 window->index, SDL_GetError());
     }
     /* does it render? */
     if (SDL_RenderClear(window->renderer) != 0) {
-        quit_fmt("cant clear status bar texture in window %u: %s",
+        quit_fmt("cannot clear status bar texture in window %u: %s",
                 window->index, SDL_GetError());
     }
 
@@ -4955,13 +4960,13 @@ static void set_window_delay(struct window *window)
 
     int display = SDL_GetWindowDisplayIndex(window->window);
     if (display < 0) {
-        quit_fmt("cant get display of window %u: %s",
+        quit_fmt("cannot get display of window %u: %s",
                 window->index, SDL_GetError());
     }
 
     SDL_DisplayMode mode;
-    if (SDL_GetCurrentDisplayMode(display, &mode) != 0)
-    {
+    if (SDL_GetCurrentDisplayMode(display, &mode) != 0 ||
+            mode.refresh_rate <= 0) {
         /* lets just guess; 60 fps is standard */
         mode.refresh_rate = 60;
     }
@@ -5041,17 +5046,17 @@ static void start_window(struct window *window)
                 -1, window->config->renderer_flags);
     }
     if (window->renderer == NULL) {
-        quit_fmt("cant create renderer for window %u: %s",
+        quit_fmt("cannot create renderer for window %u: %s",
                 window->index, SDL_GetError());
     }
 
     SDL_RendererInfo info;
     if (SDL_GetRendererInfo(window->renderer, &info) != 0) {
-        quit_fmt("cant query renderer in window %u", window->index);
+        quit_fmt("cannot query renderer in window %u", window->index);
     }
 
     if (!choose_pixelformat(window, &info)) {
-        quit_fmt("cant choose pixelformat for window %u", window->index);
+        quit_fmt("cannot choose pixelformat for window %u", window->index);
     }
 
     load_window(window);
@@ -5080,7 +5085,7 @@ static void wipe_window_aux_config(struct window *window)
 
     SDL_RendererInfo rinfo;
     if (SDL_GetRendererInfo(main_window->renderer, &rinfo) != 0) {
-        quit_fmt("cant get renderer info for main window: %s", SDL_GetError());
+        quit_fmt("cannot get renderer info for main window: %s", SDL_GetError());
     }
     window->config->renderer_flags = rinfo.flags;
     window->config->renderer_index = -1;
@@ -5100,7 +5105,7 @@ static void wipe_window_aux_config(struct window *window)
 
     int display = SDL_GetWindowDisplayIndex(main_window->window);
     if (display < 0) {
-        quit_fmt("cant get display from main window: %s", SDL_GetError());
+        quit_fmt("cannot get display from main window: %s", SDL_GetError());
     }
 
     /* center it on the screen */
@@ -5129,7 +5134,7 @@ static void wipe_window(struct window *window, int display)
 
     SDL_DisplayMode mode;
     if (SDL_GetCurrentDisplayMode(display, &mode) != 0) {
-        quit_fmt("cant get display mode for window %u: %s",
+        quit_fmt("cannot get display mode for window %u: %s",
                 window->index, SDL_GetError());
     }
 
@@ -5320,7 +5325,7 @@ static void load_subwindow(struct window *window, struct subwindow *subwindow)
         assert(subwindow->font != NULL);
     }
     if (!adjust_subwindow_geometry(window, subwindow)) {
-        quit_fmt("cant adjust geometry of subwindow %u in window %u",
+        quit_fmt("cannot adjust geometry of subwindow %u in window %u",
                 subwindow->index, window->index);
     }
     subwindow->texture = make_subwindow_texture(window,
@@ -5336,15 +5341,15 @@ static void load_subwindow(struct window *window, struct subwindow *subwindow)
                 subwindow->color.r, subwindow->color.g,
                 subwindow->color.b, subwindow->color.a) != 0)
     {
-        quit_fmt("cant set draw color for subwindow %u window %u: %s",
+        quit_fmt("cannot set draw color for subwindow %u window %u: %s",
                 subwindow->index, window->index, SDL_GetError());
     }
     if (SDL_SetRenderTarget(window->renderer, subwindow->texture) != 0) {
-        quit_fmt("cant set subwindow %u as render target in window %u: %s",
+        quit_fmt("cannot set subwindow %u as render target in window %u: %s",
                 subwindow->index, window->index, SDL_GetError());
     }
     if (SDL_RenderClear(window->renderer) != 0) {
-        quit_fmt("cant clear texture in subwindow %u window %u: %s",
+        quit_fmt("cannot clear texture in subwindow %u window %u: %s",
                 subwindow->index, window->index, SDL_GetError());
     }
 
@@ -5473,7 +5478,7 @@ static void get_string_metrics(struct font *font, const char *str, int *w, int *
     assert(font->ttf.handle != NULL);
 
     if (TTF_SizeUTF8(font->ttf.handle, str, w, h) != 0) {
-        quit_fmt("cant get string metrics for string '%s': %s", str, TTF_GetError());
+        quit_fmt("cannot get string metrics for string '%s': %s", str, TTF_GetError());
     }
 }
 


### PR DESCRIPTION
- Make subwindow - Reinitialize all subwindows
- if (use_graphics == GRAPHICS_NONE)
      tile_distorted = false; /* reset_tile_params(); */
- minor fixes from V
https://github.com/angband/angband/commit/cc3d9401b22b5d2ccae83c1b020b058cc21134fd
https://github.com/angband/angband/commit/90dfde988ec2f7fa8277fe1cfab438c25b101847
https://github.com/angband/angband/commit/67d67d902287bd81dd1f94e0e986c8bb777fbfa6
https://github.com/angband/angband/commit/77dbff6d048b07a98ac4933797137ff084c8e2ef

_the code in V has been removed, maybe it has something to do with 'int dhrclip, term->dblh_hook' ?_
```
render_tile_font_scaled()
Term_mark(col, row - tile_height);
Term_mark(col, row);
```
https://github.com/angband/angband/blob/master/src/ui-term.c#L241

> Another, less efficient way to handle double-height tiles is to use
> Term_mark() to force a position affected by a double-height tile to be
> redrawn at the next refresh.