### PR TITLE
Fix ANGBAND_FONTNAME, fonts ".FON"

### DIFF
--- a/src/client/main-sdl.c
+++ b/src/client/main-sdl.c
@@ -1606,6 +1606,10 @@ static void HelpWindowFontChange(term_window *window)
 		(h * window->rows) + window->border + window->title_height);
 
 	SetStatusButtons();
+
+    /* Hack -- set ANGBAND_FONTNAME for main window */
+    if (!Setup.initialized && window->Term_idx == 0)
+        ANGBAND_FONTNAME = window->req_font.name;
 }
 
 
@@ -2626,7 +2630,7 @@ static void SelectFileFontBrowser(sdl_Button *sender)
 		new_font.name = work;
 		new_font.preset = false;
 	}
-	if (suffix(new_font.name, ".fon"))
+	if (suffix(new_font.name, ".fon") || suffix(new_font.name, ".FON"))
     {
 		new_font.size = 0;
 		new_font.bitmapped = true;
@@ -3490,7 +3494,7 @@ static void FontActivate(sdl_Button *sender)
 			button->cap_colour = AltCapColour;
 		sdl_ButtonCaption(button, FontList[i]);
 		sdl_ButtonVisible(button, true);
-		button->activate = (suffix(FontList[i], ".fon")) ?
+		button->activate = (suffix(FontList[i], ".fon") || suffix(FontList[i], ".FON")) ?
 			SelectPresetBitmappedFont : SelectPresetScalableFont;
 	}
 


### PR DESCRIPTION
- Fixed bug fonts selection (21x31tg.fon, 24x36tg.fon -> font-tng.prf) before Setup.initialized

_in Mangband implemented_
```
/* Attempt to load font from file and bind it to 'term' "i" */
bool term_set_font()
/* Load font */
ANGBAND_FONTNAME = string_make(fontname);
```

- fonts ".fon" || ".FON"