### PR TITLE
Fix sdl2 load_subwindow() ANGBAND_FONTNAME

### DIFF
--- a/src/client/main-sdl2.c
+++ b/src/client/main-sdl2.c
@@ -5492,7 +5492,7 @@ static void load_subwindow(struct window *window, struct subwindow *subwindow)
 
     /* Hack -- set ANGBAND_FONTNAME for main window */
     if (subwindow->index == MAIN_SUBWINDOW) {
-        ANGBAND_FONTNAME = subwindow->config->font_name;
+        ANGBAND_FONTNAME = subwindow->font->name;
     }
 
     subwindow->window = window;


### PR DESCRIPTION
- Fixed, if missing sdl2init.txt file "segmentation fault" 
`subwindow->config->font_name` changed to `subwindow->font->name`