### PR TITLE
SDL2 client update

### DIFF
--- a/docs/customize.rst
+++ b/docs/customize.rst
@@ -405,3 +405,77 @@ When you leave the game, the current settings for the SDL interface are saved
 as ``sdlinit.txt`` in the same directory as is used for preference files, see
 `User Pref Files`_ for details. Those settings will be automatically reloaded
 the next time you start the SDL interface.
+
+SDL2
+****
+
+With the SDL2 front end, the application has one window that can contain the
+main window and any of the subwindows.  The application may also have up to
+three additional windows which can contain any of the subwindows.  A subwindow
+may not appear in more than of those application windows.  Unused portions of
+an application window are tiled with repetitions of the game's logo.
+
+Each of the application windows has a menu bar along the top.  The "Menu"
+entry at the left end of the menu bar has the main menu for controlling
+aspects of the SDL2 interface.
+
+Next to "Menu", are a series of one letter labels that act as toggles for the
+terminal windows shown in the application window.  Click on one to toggle it
+between on (drawn in white) and off (drawn in gray).  It is not possible to
+toggle off the main window shown in the primary application window.
+
+At the end of the menu bar are two toggle buttons labeled "Size" and "Move".
+Each will be gray if disabled or white if enabled.  Clicking on "Size" when
+it is disabled will enable it, disable "Move", turn off input to the game's
+core, and cause clicks and drags within the displayed subwindows to change
+the sizes for those subwindows.  Clicking on "Move" when it is disabled will
+enable it, disable "Size", turn off input to the game's core, and cause clicks
+and drags within the displayed subwindows to change the positions for those
+subwindows.  Disable both "Move" and "Size", by clicking on one if it is
+enabled, to restore passing input to the game's core.
+
+Within "Menu", the first entries control properties for each of the displayed
+terminal windows within that application window.  For the main window, you
+can set the font, graphical tile set, whether the window is shown with borders
+or not, and whether or not the window will be shown on top of the other windows.
+For subwindows, you can set the font, the purpose (which is a shortcut for
+enabling the subwindow content as described in
+`Showing extra info in subwindows`_), the opaqueness ("alpha") of the window,
+whether the window is shown with borders or not, and whether or not the window
+will be shown on top of the other windows.
+
+Below the entries for the contained terminal windows, is an entry,
+"Fullscreen" for toggling fullscreen mode for that application window.  That
+entry will display a rectangle at the end of the entry when fullscreen mode
+is on.  That rectangle will be absent when fullscreen mode is off.
+
+In the primary application window which contains the main window, there is an
+entry, "Send Keypad Modifier", after that for whether key strokes from the
+numeric keypad will be sent to the game with the keypad modifier set.  That
+entry will be gray when the modifier is not send and will be white when the
+modifier is sent.  Sending the modifier allows some predefined keymaps to work,
+for instance shift with 8 from the numeric keypad to run north, at the cost of
+compatibility issues with some keyboard layouts that differ from the standard
+English keyboard layout for which normal keys have equivalents on the numeric
+keypad.  https://github.com/angband/angband/issues/4522 has an example of the
+problems that can be avoided by not sending the keypad modifier.
+
+Below "Send Keypad Modifier" in the primary application window's "Menu" is
+"Menu Shortcuts...".  That allows you to set a keystroke to transfer control
+to a window's menu.  By default, no such keystrokes are defined.  That avoids
+potential conflicts with any keymaps you may have.  While in the menus,
+keystrokes can be used for navigation.  The in-game horizontal and vertical
+movement keys will work to move between controls as will Tab (to go to the
+"next" control) and Shift-Tab (to go to the previous control).  Enter will
+activate a menu item if it can be activated.  Trying to descend further into
+the menus with the in-game movement keys will also activate if a menu item if
+it is as deep as you can go.  Below "Menu Shortcuts..." is "Windows":  use
+that to bring up one of the additional application windows.
+
+The final two entries in "Menu" are "About" for displaying an information
+dialog about the game and "Quit" to save the game and exit.
+
+When you leave the game, the current settings for the SDL interface are saved
+as ``sdl2init.txt`` in the same directory as is used for preference files, see
+`User Pref Files`_ for details.  Those settings will be automatically reloaded
+the next time you start the SDL2 interface.

--- a/src/Makefile.src
+++ b/src/Makefile.src
@@ -106,7 +106,11 @@ BASEMAINFILES = client/main.o
 
 GCUMAINFILES = client/main-gcu.o
 
-SDL2MAINFILES = client/main-sdl2.o
+SDL2MAINFILES = \
+	client/main-sdl2.o \
+	sdl2/pui-ctrl.o \
+	sdl2/pui-dlg.o \
+	sdl2/pui-misc.o
 
 SDLMAINFILES = client/main-sdl.o
 

--- a/src/android/pwmangclient/jni/src/Android.mk
+++ b/src/android/pwmangclient/jni/src/Android.mk
@@ -1,6 +1,7 @@
 LOCAL_PATH := $(call my-dir)
 
 MC_PATH := ../../../../../src/client
+PUI_PATH := ../../../../../src/sdl2
 CMN_PATH := ../../../../../src/common
 
 include $(CLEAR_VARS)
@@ -19,6 +20,9 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/$(SDL_PATH)/include \
 
 LOCAL_SRC_FILES := $(MC_PATH)/main.c \
 		$(MC_PATH)/main-sdl2.c \
+		$(PUI_PATH)/pui-ctrl.c \
+		$(PUI_PATH)/pui-dlg.c \
+		$(PUI_PATH)/pui-misc.c \
 		$(MC_PATH)/snd-sdl.c \
 		$(CMN_PATH)/buildid.c \
 		$(MC_PATH)/conf.c \

--- a/src/bcc32c/makefile.sdl2
+++ b/src/bcc32c/makefile.sdl2
@@ -113,7 +113,10 @@ CLI_SRCS = \
   ..\client\ui-prefs.c \
   ..\client\ui-spell.c \
   ..\client\ui-store.c \
-  ..\client\ui-term.c
+  ..\client\ui-term.c \
+  ..\sdl2\pui-ctrl.c \
+  ..\sdl2\pui-dlg.c \
+  ..\sdl2\pui-misc.c
 
 CLI_OBJS = \
   ..\common\buildid.obj \
@@ -177,7 +180,10 @@ CLI_OBJS = \
   ..\client\ui-prefs.obj \
   ..\client\ui-spell.obj \
   ..\client\ui-store.obj \
-  ..\client\ui-term.obj
+  ..\client\ui-term.obj \
+  ..\sdl2\pui-ctrl.obj \
+  ..\sdl2\pui-dlg.obj \
+  ..\sdl2\pui-misc.obj
 
 default: $(CLI_EXE)
 

--- a/src/client/c-cmd.c
+++ b/src/client/c-cmd.c
@@ -179,6 +179,7 @@ static void view_map_aux(uint8_t mode)
 }
 
 
+/* Display map in subwindow "Term->view_map_hook" */
 void do_cmd_view_map_w(void)
 {
     ui_event ke = EVENT_EMPTY;

--- a/src/client/main-sdl2.c
+++ b/src/client/main-sdl2.c
@@ -21,39 +21,31 @@
 
 #ifdef USE_SDL2
 
+#include "../sdl2/pui-ctrl.h"
+#include "../sdl2/pui-dlg.h"
+#include "../sdl2/pui-misc.h"
+#include "../sdl2/pui-win.h"
+
 #ifdef WINDOWS
-#include "..\_SDL2\SDL.h"
 #include "..\_SDL2\SDL_image.h"
-#include "..\_SDL2\SDL_ttf.h"
 #else
-#include "SDL.h"
 #include "SDL_image.h"
-#include "SDL_ttf.h"
 #endif
 
 #define MAX_SUBWINDOWS \
     ANGBAND_TERM_MAX
 /* that should be plenty... */
 #define MAX_WINDOWS 4
-#define MAX_BUTTONS 32
-
-/*
- * Since font selection goes through a menu panel with MAX_BUTTONS, there's
- * no point to having any more than can be selected with that menu.
- * Hack -- MAX_BUTTONS * 2 for 'font_page'
- */
-#define MAX_FONTS (MAX_BUTTONS * 2)
 
 #define INIT_SDL_FLAGS \
     (SDL_INIT_VIDEO)
 #define INIT_IMG_FLAGS \
     (IMG_INIT_PNG)
 
-/* Chat window (term_chat) */
-#define CHAT_SUBWINDOW PMSG_TERM
-
 /* this is the main term screen, where all the action takes place */
 #define MAIN_SUBWINDOW 0
+/* chat window (term_chat) */
+#define CHAT_SUBWINDOW PMSG_TERM
 /* for symmetry with main subwindow */
 #define MAIN_WINDOW 0
 /* size of the keypress queue (term->key_queue) */
@@ -102,16 +94,11 @@
 #define DEFAULT_FONT_W 10
 #define DEFAULT_FONT_H 20
 
-#define DEFAULT_STATUS_BAR_FONT "8x13x.fon"
+#define DEFAULT_DIALOG_FONT "8x13x.fon"
 
 #define MAX_VECTOR_FONT_SIZE 36
 #define MIN_VECTOR_FONT_SIZE 4
 
-#define DEFAULT_BUTTON_BORDER 8
-#define DEFAULT_LINE_HEIGHT(h) ((h) * 150 / 100)
-#define DEFAULT_MENU_LINE_HEIGHT(h) ((h) * 200 / 100)
-#define DEFAULT_MENU_LINE_WIDTH(w) \
-    ((w) + DEFAULT_BUTTON_BORDER + DEFAULT_XTRA_BORDER)
 /* update period in window delays (160 milliseconds, assuming 60 fps) */
 #define DEFAULT_IDLE_UPDATE_PERIOD 10
 
@@ -121,45 +108,13 @@
     COLOUR_DARK
 #define DEFAULT_SUBWINDOW_CURSOR_COLOR \
     COLOUR_YELLOW
-#define DEFAULT_STATUS_BAR_BG_COLOR \
-    COLOUR_DARK
 #define DEFAULT_SHADE_COLOR \
     COLOUR_SHADE
 #define DEFAULT_SUBWINDOW_BORDER_COLOR \
     COLOUR_SHADE
-#define DEFAULT_STATUS_BAR_BUTTON_ACTIVE_COLOR \
-    COLOUR_WHITE
-#define DEFAULT_STATUS_BAR_BUTTON_INACTIVE_COLOR \
-    COLOUR_L_DARK
-
-#define DEFAULT_MENU_FG_ACTIVE_COLOR \
-    COLOUR_WHITE
-#define DEFAULT_MENU_FG_INACTIVE_COLOR \
-    COLOUR_WHITE
-#define DEFAULT_MENU_BG_ACTIVE_COLOR \
-    COLOUR_SHADE
-#define DEFAULT_MENU_BG_INACTIVE_COLOR \
-    COLOUR_DARK
-
-#define DEFAULT_MENU_TOGGLE_FG_ACTIVE_COLOR \
-    COLOUR_WHITE
-#define DEFAULT_MENU_TOGGLE_FG_INACTIVE_COLOR \
-    COLOUR_L_DARK
-
-#define DEFAULT_MENU_PANEL_OUTLINE_COLOR \
-    COLOUR_SHADE
 
 #define DEFAULT_ERROR_COLOR \
     COLOUR_RED
-
-#define DEFAULT_ABOUT_BG_COLOR \
-    COLOUR_SHADE
-#define DEFAULT_ABOUT_BORDER_OUTER_COLOR \
-    COLOUR_L_DARK
-#define DEFAULT_ABOUT_BORDER_INNER_COLOR \
-    COLOUR_WHITE
-#define DEFAULT_ABOUT_TEXT_COLOR \
-    COLOUR_WHITE
 
 /* shockbolt's tiles are 64x64; dungeon is 198 tiles long;
  * 64 * 198 is 12672 which is bigger than any possible texture! */
@@ -186,9 +141,6 @@
 #define DEFAULT_SNAP_RANGE \
     DEFAULT_FONT_W
 
-#define CHECK_BUTTON_DATA_TYPE(button, data_type) \
-    assert((button)->data.type == (data_type))
-
 enum wallpaper_mode {
     /* so that we won't forget to actually set wallpaper */
     WALLPAPER_INVALID = 0,
@@ -196,42 +148,6 @@ enum wallpaper_mode {
     WALLPAPER_TILED,
     WALLPAPER_CENTERED,
     WALLPAPER_SCALED
-};
-
-enum button_data_type {
-    BUTTON_DATA_INVALID = 0,
-    BUTTON_DATA_NONE,
-    BUTTON_DATA_INT,
-    BUTTON_DATA_UNSIGNED,
-    BUTTON_DATA_SUBWINDOW,
-    BUTTON_DATA_FONT,
-    BUTTON_DATA_TERM_FLAG,
-    BUTTON_DATA_ALPHA
-};
-
-enum button_movesize {
-    BUTTON_MOVESIZE_INVALID = 0,
-    BUTTON_MOVESIZE_MOVING,
-    BUTTON_MOVESIZE_SIZING
-};
-
-enum button_tile_scale {
-    BUTTON_TILE_SIZE_INVALID = 0,
-    BUTTON_TILE_SIZE_WIDTH,
-    BUTTON_TILE_SIZE_HEIGHT
-};
-
-enum button_volume {
-    BUTTON_VOLUME_INVALID = 0,
-    BUTTON_VOLUME_SOUND,
-    BUTTON_VOLUME_MUSIC
-};
-
-enum button_caption_position {
-    CAPTION_POSITION_INVALID = 0,
-    CAPTION_POSITION_CENTER,
-    CAPTION_POSITION_LEFT,
-    CAPTION_POSITION_RIGHT
 };
 
 enum font_type {
@@ -283,7 +199,7 @@ struct font {
     char *name;
     char *path;
     int size;
-    /* index of font in g_font_info array */
+    /* index of font in the application's fonts array */
     size_t index;
 
     struct font_cache cache;
@@ -330,9 +246,17 @@ struct subwindow {
     int cols;
 
     /* struct ttf also has this information; these members are
-     * just for convinience */
+     * just for convenience */
     int font_width;
     int font_height;
+
+    /*
+     * These are transiently used during font selection for the subwindow.
+     * The font size must be >= min_font_size and < max_font_size to
+     * match the constraints of the subwindow's miniumum number of columns
+     * and rows and the size of the window containing the subwindow.
+     */
+    int min_font_size, max_font_size;
 
     /* coordinates of full rect are relative to coordinates of window
      * (basically, full rect is texture) */
@@ -354,118 +278,9 @@ struct subwindow {
 
     struct font *font;
 
-    struct window *window;
+    struct sdlpui_window *window;
     struct _term *term;
-};
-
-struct button;
-
-struct button_bank {
-    struct button *buttons;
-    size_t size;
-    size_t number;
-};
-
-struct menu_panel {
-    SDL_Rect rect;
-    struct button_bank button_bank;
-    struct menu_panel *next;
-};
-
-typedef void (*button_render)(const struct window *window,
-        struct button *button);
-typedef bool (*button_event)(struct window *window,
-        struct button *button, const SDL_Event *event);
-typedef void (*button_menu)(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel);
-
-struct font_value {
-    struct subwindow *subwindow;
-    /* index of font in g_font_info array */
-    size_t index;
-    bool size_ok;
-};
-
-struct term_flag_value {
-    struct subwindow *subwindow;
-    uint32_t flag;
-};
-
-struct alpha_value {
-    struct subwindow *subwindow;
-    int real_value;
-    int show_value;
-};
-
-struct button_data {
-    enum button_data_type type;
-    union {
-        int int_value;
-        unsigned unsigned_value;
-        struct subwindow *subwindow_value;
-        struct font_value font_value;
-        struct term_flag_value term_flag_value;
-        struct alpha_value alpha_value;
-    } value;
-};
-
-struct menu_elem {
-    const char *caption;
-    struct button_data data;
-    button_render on_render;
-    button_menu on_menu;
-    bool disabled;
-};
-
-struct button_callbacks {
-    /* this function should render the button;
-     * otherwise, the button will be invisible */
-    button_render on_render;
-    /* event handler for status bar buttons */
-    button_event on_event;
-    /* event handler for buttons in "Menu" */
-    button_menu on_menu;
-};
-
-struct button {
-    /* disabled, if true, means that the on_event or on_menu callbacks
-     * won't be invoked and the button will be drawn with an altered
-     * appearance to indicate that it currently doesn't do anything. */
-    bool disabled;
-    /* selected means the user pointed at button and
-     * pressed mouse button (but not released yet) */
-    bool selected;
-    /* highlighted means the user pointed
-     * at button but not clicking yet */
-    bool highlighted;
-    /* At least, that was the theory; buttons in "Menu" work a bit differently,
-     * some are selected when the user points at button, all are highlighted
-     * regardless of what event happened on them (click or mouse motion)... */
-
-    char *caption;
-
-    SDL_Rect full_rect;
-    SDL_Rect inner_rect;
-
-    struct button_data data;
-    struct button_callbacks callbacks;
-};
-
-struct status_bar {
-    struct font *font;
-
-    struct button_bank button_bank;
-    struct menu_panel *menu_panel;
-
-    struct window *window;
-
-    SDL_Rect full_rect;
-    SDL_Rect inner_rect;
-    SDL_Color color;
-    SDL_Texture *texture;
-
-    bool in_menu;
+    struct my_app *app;
 };
 
 struct graphics {
@@ -510,14 +325,9 @@ struct wallpaper {
     enum wallpaper_mode mode;
 };
 
-struct stipple {
-    int w, h;
-    SDL_Texture *texture;
-};
-
-/* struct window is a real window on screen, it has one or more
+/* struct sdlpui_window is a real window on screen, it has one or more
  * subwindows (terms) in it */
-struct window {
+struct sdlpui_window {
     bool inited;
     bool loaded;
 
@@ -525,11 +335,11 @@ struct window {
     Uint32 id;
     /* and this is our id, mostly for debugging */
     unsigned index;
+    /* index of transiently outlined subwindow */
+    unsigned outlined_subwindow;
 
     struct window_config *config;
 
-    /* does window have mouse focus? */
-    bool focus;
     /* window has changed and must be redrawn */
     bool dirty;
 
@@ -552,17 +362,43 @@ struct window {
 
     SDL_Window *window;
     SDL_Renderer *renderer;
+    /* The font to use for this window's dialogs and menus */
+    struct font *dialog_font;
+    /* The status bar (i.e. menu bar) for the window */
+    struct sdlpui_dialog *status_bar;
+    /* The buttons in the status bar for moving and resizing the window */
+    struct sdlpui_control *move_button;
+    struct sdlpui_control *size_button;
+    /* The about dialog; NULL if not currently displayed */
+    struct sdlpui_dialog *infod;
+    /* The keyboard shortcut dialog; NULL if not currently displayed */
+    struct sdlpui_dialog *shorte;
 
     int pixelformat;
 
     struct wallpaper wallpaper;
-    struct stipple stipple;
+    struct sdlpui_stipple stipple;
     struct move_state move_state;
     struct size_state size_state;
-    struct status_bar status_bar;
     struct graphics graphics;
 
     struct subwindow *subwindows[MAX_SUBWINDOWS];
+
+    /* Point back to the containing application */
+    struct my_app *app;
+
+    /*
+     * These are the head and tail of the stack of menus/dialogs for this
+     * window.  Both will be NULL if no menus/dialogs are active.
+     */
+    struct sdlpui_dialog *d_head, *d_tail;
+
+    /*
+     * These point to the dialog/menu that should receive mouse events or
+     * keyboard events, respectively.  If NULL, events will be directed
+     * to the game's core.
+     */
+    struct sdlpui_dialog *d_mouse, *d_key;
 };
 
 struct font_info {
@@ -571,70 +407,106 @@ struct font_info {
     int size;
     size_t index;
     enum font_type type;
-    bool loaded;
 };
 
-const char help_sdl2[] = "SDL2 frontend";
-static SDL_Color g_colors[MAX_COLORS];
-static struct font_info g_font_info[MAX_FONTS];
-/* these arrays contain windows and terms that the ui operates on */
-static struct subwindow g_subwindows[MAX_SUBWINDOWS];
-static struct window g_windows[MAX_WINDOWS];
-/* True if KC_MOD_KEYPAD will be sent for numeric keypad keys at the expense
- * of not handling some keyboard layouts properly. */
-static int g_kp_as_mod = 1;
+struct shortcut_editor_data {
+    struct sdlpui_control labels[MAX_WINDOWS];
+    struct sdlpui_control shortcut_displays[MAX_WINDOWS];
+    struct sdlpui_control change_buttons[MAX_WINDOWS];
+    struct sdlpui_control clear_buttons[MAX_WINDOWS];
+    struct sdlpui_control prompt_label;
+    struct sdlpui_control close_button;
+    struct sdlpui_control reset_button;
+    int changing_shortcut;
+};
 
-/* term_view_map_hook */
-static int view_map_hook_mod = 1;
-
-/* handle_menu_font_names_page */
-static bool font_page = false;
+struct my_app {
+    /*
+     * The string ANGBAND_DIR_USER is freed before calling quit_hook(),
+     * so we need to save the path to the config file.
+     */
+    char config_file[4096];
+    /* the game's color table translated into what SDL expects */
+    SDL_Color colors[MAX_COLORS];
+    /*
+     * fonts from the game's lib/fonts directory that can be selected
+     * directly from the menus
+     */
+    struct font_info *fonts;
+    struct subwindow subwindows[MAX_SUBWINDOWS];
+    struct sdlpui_window windows[MAX_WINDOWS];
+    struct keypress menu_shortcuts[MAX_WINDOWS];
+    /*
+     * point to the window that should receive mouse and key events,
+     * respectively
+     */
+    struct sdlpui_window *w_mouse;
+    struct sdlpui_window *w_key;
+    /* Number of entries stored in fonts */
+    int font_count;
+    /* Number of entries allocated in fonts */
+    int font_alloc;
+    /*
+     * true if KC_MOD_KEYPAD will be sent for numeric keypad keys at the
+     * expense of not handling some keyboard layouts properly
+     */
+    bool kp_as_mod;
+};
 
 /* Forward declarations */
 
-static void init_globals(void);
-static void free_globals(void);
-static bool read_config_file(void);
-static void dump_config_file(void);
-static void init_colors(void);
-static void start_windows(void);
-static void start_window(struct window *window);
+static void init_globals(struct my_app *a);
+static void free_globals(struct my_app *a);
+static bool read_config_file(struct my_app *a);
+static void dump_config_file(const struct my_app *a);
+static void init_colors(struct my_app *a);
+static void start_windows(struct my_app *a);
+static void start_window(struct sdlpui_window *window);
 static void load_font(struct font *font);
 static bool reload_font(struct subwindow *subwindow,
         const struct font_info *info);
 static void free_font(struct font *font);
-static const struct font_info *find_font_info(const char *name);
-static void get_string_metrics(struct font *font, const char *str, int *w, int *h);
-static struct window *get_new_window(unsigned index);
-static void wipe_window(struct window *window, int display);
+static const struct font_info *find_font_info(const struct font_info *fonts,
+        int nfonts, const char *name);
+static struct font *make_font(const struct sdlpui_window *window,
+        const char *name, int size);
+static struct sdlpui_window *get_new_window(struct my_app *a, unsigned index);
+static void wipe_window(struct sdlpui_window *window, int display);
 /* create default config for spawning a window via gui */
-static void wipe_window_aux_config(struct window *window);
-static void adjust_window_geometry(struct window *window);
-static void free_window(struct window *window);
-static struct window *get_window_by_id(Uint32 id);
-static struct window *get_window_direct(unsigned index);
-static bool has_visible_subwindow(const struct window *window, unsigned index);
-static void resize_window(struct window *window, int w, int h);
-static struct subwindow *get_new_subwindow(unsigned index);
-static void load_subwindow(struct window *window, struct subwindow *subwindow);
-static bool is_subwindow_loaded(unsigned index);
-static struct subwindow *transfer_subwindow(struct window *window, unsigned index);
-static struct subwindow *get_subwindow_by_xy(const struct window *window, int x, int y);
-static struct subwindow *get_subwindow_by_index(const struct window *window,
-        unsigned index, bool visible);
-static struct subwindow *get_subwindow_direct(unsigned index);
+static void wipe_window_aux_config(struct sdlpui_window *window);
+static void adjust_window_geometry(struct sdlpui_window *window);
+static void free_window(struct sdlpui_window *window);
+static struct sdlpui_window *get_window_by_id(struct my_app *a, Uint32 id);
+static struct sdlpui_window *get_window_direct(struct my_app *a,
+        unsigned index);
+static void resize_window(struct sdlpui_window *window, int w, int h);
+static struct subwindow *get_new_subwindow(struct my_app *a, unsigned index);
+static void load_subwindow(struct sdlpui_window *window,
+        struct subwindow *subwindow);
+static bool is_subwindow_loaded(struct my_app *a, unsigned index);
+static struct subwindow *transfer_subwindow(struct sdlpui_window *window,
+        unsigned index);
+static struct subwindow *get_subwindow_by_xy(const struct sdlpui_window *window,
+        int x, int y);
+static struct subwindow *get_subwindow_by_index(
+        const struct sdlpui_window *window, unsigned index,
+        bool visible);
+static struct subwindow *get_subwindow_direct(struct my_app *a, unsigned index);
 /* this function loads new subwindow if it's not already loaded */
-static struct subwindow *make_subwindow(struct window *window, unsigned index);
-static void sort_to_top(struct window *window);
-static void bring_to_top(struct window *window, struct subwindow *subwindow);
+static struct subwindow *make_subwindow(struct sdlpui_window *window,
+        unsigned index);
+static void sort_to_top(struct sdlpui_window *window);
+static void bring_to_top(struct sdlpui_window *window,
+        struct subwindow *subwindow);
 static void render_borders(struct subwindow *subwindow);
-static SDL_Texture *load_image(const struct window *window, const char *path);
-static void reload_all_graphics(graphics_mode *mode);
+static SDL_Texture *load_image(const struct sdlpui_window *window,
+        const char *path);
+static void reload_all_graphics(struct my_app *a, graphics_mode *mode);
 static void free_graphics(struct graphics *graphics);
-static void load_terms(void);
+static void load_terms(struct my_app *a);
 static void load_term(struct subwindow *subwindow);
 static void clear_pw_flag(struct subwindow *subwindow);
-static bool adjust_subwindow_geometry(const struct window *window,
+static bool adjust_subwindow_geometry(const struct sdlpui_window *window,
         struct subwindow *subwindow);
 static bool is_ok_col_row(const struct subwindow *subwindow,
         const SDL_Rect *rect, int cell_w, int cell_h);
@@ -643,19 +515,175 @@ static void resize_rect(SDL_Rect *rect,
 static void crop_rects(SDL_Rect *src, SDL_Rect *dst);
 static bool is_point_in_rect(int x, int y, const SDL_Rect *rect);
 static bool is_close_to(int a, int b, unsigned range);
-static bool is_over_status_bar(const struct status_bar *status_bar, int x, int y);
-static void make_button_bank(struct button_bank *bank);
-static void free_button_bank(struct button_bank *button_bank);
-static void free_menu_panel(struct menu_panel *menu_panel);
-static struct menu_panel *get_menu_panel_by_xy(struct menu_panel *menu_panel,
-        int x, int y);
-static void refresh_angband_terms(void);
+static void handle_window_closed(struct my_app *a,
+        struct sdlpui_window *window);
+static void refresh_angband_terms(struct my_app *a);
 static void handle_quit(void);
-static void wait_anykey(void);
+static void wait_anykey(struct my_app *a);
+static void keyboard_event_to_angband_key(const SDL_KeyboardEvent *key,
+        bool kp_as_mod, keycode_t *ch, uint8_t *mods);
+static void textinput_event_to_angband_key(const SDL_TextInputEvent *key,
+        bool kp_as_mod, keycode_t *ch, uint8_t *mods);
+
+/* Global variables. */
+
+const char help_sdl2[] = "SDL2 frontend";
+static struct my_app g_app;
+static Uint32 SHORTCUT_EDITOR_CODE;
+/* display map in subwindow term_view_map_hook() */
+static bool view_map_hook_mod = true;
+
+/*
+ * Provide the hooks needed by primitive UI toolkit for SDL2.
+ */
+SDL_Renderer *sdlpui_get_renderer(struct sdlpui_window *w)
+{
+    return w->renderer;
+}
+
+TTF_Font *sdlpui_get_ttf(struct sdlpui_window *w)
+{
+    assert(w->dialog_font && w->dialog_font->ttf.handle);
+    return w->dialog_font->ttf.handle;
+}
+
+struct sdlpui_stipple *sdlpui_get_stipple(struct sdlpui_window *w)
+{
+    return &w->stipple;
+}
+
+const SDL_Color *sdlpui_get_color(struct sdlpui_window *w, int role)
+{
+    int idx;
+
+    switch (role) {
+    case SDLPUI_COLOR_MENU_BG:
+    case SDLPUI_COLOR_COUNTERSINK:
+        idx = COLOUR_DARK;
+        break;
+
+    case SDLPUI_COLOR_MENU_FG:
+    case SDLPUI_COLOR_DIALOG_FG:
+    case SDLPUI_COLOR_DIALOG_BORDER:
+        idx = COLOUR_WHITE;
+        break;
+
+    case SDLPUI_COLOR_MENU_BORDER:
+    case SDLPUI_COLOR_DIALOG_BG:
+        idx = COLOUR_SHADE;
+        break;
+
+    default:
+        /*
+         * Should not happen; assign a safe index in case assertions
+         * are optimized away.
+         */
+        SDL_assert(0);
+        idx = 0;
+        break;
+    }
+
+    SDL_assert(idx >= 0 && idx < MAX_COLORS);
+    return &w->app->colors[idx];
+}
+
+void sdlpui_signal_redraw(struct sdlpui_window *w)
+{
+    w->dirty = true;
+}
+
+void sdlpui_dialog_push_to_top(struct sdlpui_window *w, struct sdlpui_dialog *d)
+{
+    bool redraw = true;
+
+    /* Unlink. */
+    if (d->next) {
+        d->next->prev = d->prev;
+    } else if (w->d_tail == d) {
+        w->d_tail = d->prev;
+    }
+    if (d->prev) {
+        d->prev->next = d->next;
+    } else if (w->d_head == d) {
+        redraw = false;
+        w->d_head = d->next;
+    }
+
+    /* Put at the top. */
+    d->prev = NULL;
+    d->next = w->d_head;
+    if (d->next) {
+        d->next->prev = d;
+    } else {
+        SDL_assert(!w->d_tail);
+        w->d_tail = d;
+    }
+    w->d_head = d;
+
+    if (redraw) {
+        sdlpui_signal_redraw(w);
+    }
+}
+
+void sdlpui_dialog_pop(struct sdlpui_window *w, struct sdlpui_dialog *d)
+{
+    if (w->d_mouse == d) {
+        w->d_mouse = NULL;
+    }
+    if (w->d_key == d) {
+        w->d_key = NULL;
+    }
+    if (d->next) {
+        d->next->prev = d->prev;
+    } else {
+        SDL_assert(w->d_tail == d);
+        w->d_tail = d->prev;
+    }
+    if (d->prev) {
+        d->prev->next = d->next;
+    } else {
+        SDL_assert(w->d_head == d);
+        w->d_head = d->next;
+    }
+    w->dirty = true;
+}
+
+void sdlpui_dialog_gain_key_focus(struct sdlpui_window *w,
+        struct sdlpui_dialog *d)
+{
+    w->d_key = d;
+}
+
+void sdlpui_dialog_yield_key_focus(struct sdlpui_window *w,
+        struct sdlpui_dialog *d)
+{
+    if (w->d_key == d) {
+        w->d_key = NULL;
+    }
+}
+
+void sdlpui_dialog_gain_mouse_focus(struct sdlpui_window *w,
+        struct sdlpui_dialog *d)
+{
+    w->d_mouse = d;
+}
+
+void sdlpui_dialog_yield_mouse_focus(struct sdlpui_window *w,
+        struct sdlpui_dialog *d)
+{
+    if (w->d_mouse == d) {
+        w->d_mouse = NULL;
+    }
+}
+
+void sdlpui_force_quit(void)
+{
+    quit("sdlpui failure");
+}
 
 /* Functions */
 
-static void render_clear(const struct window *window,
+static void render_clear(const struct sdlpui_window *window,
         SDL_Texture *texture, const SDL_Color *color)
 {
     SDL_SetRenderTarget(window->renderer, texture);
@@ -664,7 +692,7 @@ static void render_clear(const struct window *window,
     SDL_RenderClear(window->renderer);
 }
 
-static void render_wallpaper_tiled(const struct window *window)
+static void render_wallpaper_tiled(const struct sdlpui_window *window)
 {
     SDL_SetRenderTarget(window->renderer, NULL);
 
@@ -682,13 +710,13 @@ static void render_wallpaper_tiled(const struct window *window)
     }
 }
 
-static void render_wallpaper_scaled(const struct window *window)
+static void render_wallpaper_scaled(const struct sdlpui_window *window)
 {
     SDL_SetRenderTarget(window->renderer, NULL);
     SDL_RenderCopy(window->renderer, window->wallpaper.texture, NULL, NULL);
 }
 
-static void render_wallpaper_centered(const struct window *window)
+static void render_wallpaper_centered(const struct sdlpui_window *window)
 {
     SDL_Rect rect;
 
@@ -701,7 +729,7 @@ static void render_wallpaper_centered(const struct window *window)
     SDL_RenderCopy(window->renderer, window->wallpaper.texture, NULL, &rect);
 }
 
-static void render_background(const struct window *window)
+static void render_background(const struct sdlpui_window *window)
 {
     render_clear(window, NULL, &window->color);
 
@@ -724,73 +752,7 @@ static void render_background(const struct window *window)
     }
 }
 
-static void stipple_button(const struct window *window,
-        const struct button *button, SDL_Texture *dst_texture)
-{
-    SDL_Rect srect = { 0, 0, 0, 0 }, drect;
-    int ylim = button->full_rect.y + button->full_rect.h;
-    int xlim = button->full_rect.x + button->full_rect.w;
-
-    if (!window->stipple.texture) {
-        return;
-    }
-    SDL_SetRenderTarget(window->renderer, dst_texture);
-    for (drect.y = button->full_rect.y; drect.y < ylim;
-            drect.y += window->stipple.h) {
-        if (drect.y + window->stipple.h > ylim) {
-            drect.h = ylim - drect.y;
-        } else {
-            drect.h = window->stipple.h;
-        }
-        srect.h = drect.h;
-        for (drect.x = button->full_rect.x; drect.x < xlim;
-                drect.x += window->stipple.w) {
-            if (drect.x + window->stipple.w > xlim) {
-                drect.w = xlim - drect.x;
-            } else {
-                drect.w = window->stipple.w;
-            }
-            srect.w = drect.w;
-            SDL_RenderCopy(window->renderer,
-                window->stipple.texture, &srect, &drect);
-        }
-    }
-}
-
-static void render_all(const struct window *window)
-{
-    render_background(window);
-
-    SDL_RenderCopy(window->renderer,
-            window->status_bar.texture, NULL, &window->status_bar.full_rect);
-
-    for (size_t i = 0; i < N_ELEMENTS(window->subwindows); i++) {
-        struct subwindow *subwindow = window->subwindows[i];
-        if (subwindow != NULL && subwindow->visible) {
-            SDL_RenderCopy(window->renderer,
-                    subwindow->texture,
-                    NULL, &subwindow->full_rect);
-        }
-    }
-}
-
-static void render_status_bar(const struct window *window)
-{
-    render_clear(window, window->status_bar.texture, &window->status_bar.color);
-
-    for (size_t i = 0; i < window->status_bar.button_bank.number; i++) {
-        struct button *button = &window->status_bar.button_bank.buttons[i];
-        if (button->callbacks.on_render != NULL) {
-            button->callbacks.on_render(window, button);
-        }
-        if (button->disabled) {
-            stipple_button(window, button,
-                window->status_bar.texture);
-        }
-    }
-}
-
-static void render_outline_rect(const struct window *window,
+static void render_outline_rect(const struct sdlpui_window *window,
         SDL_Texture *texture, const SDL_Rect *rect, const SDL_Color *color)
 {
     SDL_SetRenderTarget(window->renderer, texture);
@@ -799,7 +761,7 @@ static void render_outline_rect(const struct window *window,
     SDL_RenderDrawRect(window->renderer, rect);
 }
 
-static void render_outline_rect_width(const struct window *window,
+static void render_outline_rect_width(const struct sdlpui_window *window,
         SDL_Texture *texture, const SDL_Rect *rect, const SDL_Color *color, int width)
 {
     SDL_Rect dst = *rect;
@@ -810,7 +772,7 @@ static void render_outline_rect_width(const struct window *window,
     }
 }
 
-static void render_fill_rect(const struct window *window,
+static void render_fill_rect(const struct sdlpui_window *window,
         SDL_Texture *texture, const SDL_Rect *rect, const SDL_Color *color)
 {
     SDL_SetRenderTarget(window->renderer, texture);
@@ -819,13 +781,65 @@ static void render_fill_rect(const struct window *window,
     SDL_RenderFillRect(window->renderer, rect);
 }
 
-static void render_window_in_menu(const struct window *window)
+static void render_all(struct sdlpui_window *window)
 {
+    size_t i;
+    struct sdlpui_dialog *d;
+
+    render_background(window);
+
+    for (d = window->d_tail; d; d = d->prev) {
+        if (d->texture) {
+            SDL_RenderCopy(window->renderer, d->texture, NULL,
+                &d->rect);
+        } else if (d->ftb->render) {
+            (*d->ftb->render)(d, window);
+        }
+    }
+
+    for (i = 0; i < N_ELEMENTS(window->subwindows); i++) {
+        struct subwindow *subwindow = window->subwindows[i];
+
+        if (subwindow != NULL && subwindow->visible) {
+            SDL_RenderCopy(window->renderer,
+                    subwindow->texture,
+                    NULL, &subwindow->full_rect);
+        }
+    }
+}
+
+static void render_status_bar(struct sdlpui_window *window)
+{
+    struct sdlpui_dialog *d;
+
+    for (d = window->d_tail; d; d = d->prev) {
+        if (d->dirty) {
+            if (d->ftb->render) {
+                (*d->ftb->render)(d, window);
+            }
+            if (d->texture) {
+                SDL_RenderCopy(window->renderer, d->texture,
+                    NULL, &d->rect);
+            }
+        } else if (d->texture) {
+            SDL_RenderCopy(window->renderer, d->texture, NULL,
+                &d->rect);
+        } else if (d->ftb->render) {
+            (*d->ftb->render)(d, window);
+        }
+    }
+}
+
+static void render_window_while_menu_active(struct sdlpui_window *window)
+{
+    size_t i;
+    struct sdlpui_dialog *d;
+
     render_background(window);
 
     SDL_SetRenderTarget(window->renderer, NULL);
 
-    for (size_t i = 0; i < N_ELEMENTS(window->subwindows); i++) {
+    for (i = 0; i < N_ELEMENTS(window->subwindows); i++) {
         struct subwindow *subwindow = window->subwindows[i];
         if (subwindow != NULL && subwindow->visible) {
             if (subwindow->sizing_rect.w > 0 && subwindow->sizing_rect.h > 0) {
@@ -842,14 +856,40 @@ static void render_window_in_menu(const struct window *window)
             SDL_RenderCopy(window->renderer,
                     subwindow->texture,
                     NULL, &subwindow->full_rect);
+            if (subwindow->index == window->outlined_subwindow) {
+                int outline_width = (subwindow->full_rect.w
+                    - subwindow->inner_rect.w) / 2
+                    - subwindow->borders.width;
+                SDL_Rect outline_rect = subwindow->full_rect;
+
+                resize_rect(&outline_rect,
+                    subwindow->borders.width,
+                    subwindow->borders.width,
+                    -subwindow->borders.width,
+                    -subwindow->borders.width);
+                render_outline_rect_width(window, NULL,
+                    &outline_rect,
+                    &subwindow->app->colors[DEFAULT_SUBWINDOW_BORDER_COLOR],
+                    outline_width);
+            }
         }
     }
 
-    /* render it last to allow the menu to draw over subwindows */
-    render_status_bar(window);
-    SDL_SetRenderTarget(window->renderer, NULL);
-    SDL_RenderCopy(window->renderer,
-            window->status_bar.texture, NULL, &window->status_bar.full_rect);
+    /*
+     * Render any dialogs or menus last, back to front, so they can draw
+     * over subwindows.
+     */
+    for (d = window->d_tail; d; d = d->prev) {
+        if (d->ftb->render && (d->dirty || !d->texture)) {
+            (*d->ftb->render)(d, window);
+        }
+        d->dirty = false;
+        if (d->texture) {
+            SDL_SetRenderTarget(window->renderer, NULL);
+            SDL_RenderCopy(window->renderer, d->texture, NULL,
+                &d->rect);
+        }
+    }
 }
 
 static void set_subwindow_alpha(struct subwindow *subwindow, int alpha)
@@ -858,7 +898,7 @@ static void set_subwindow_alpha(struct subwindow *subwindow, int alpha)
     SDL_SetTextureAlphaMod(subwindow->aux_texture, alpha);
 }
 
-static void set_subwindows_alpha(const struct window *window, int alpha)
+static void set_subwindows_alpha(const struct sdlpui_window *window, int alpha)
 {
     for (size_t i = 0; i < N_ELEMENTS(window->subwindows); i++) {
         struct subwindow *subwindow = window->subwindows[i];
@@ -870,40 +910,38 @@ static void set_subwindows_alpha(const struct window *window, int alpha)
 
 /* this function allows to perform special things that are not
  * needed while playing the game, like moving terms */
-static void redraw_window_in_menu(struct window *window)
+static void redraw_window_while_menu_active(struct sdlpui_window *window)
 {
     set_subwindows_alpha(window, window->alpha);
-    render_window_in_menu(window);
+    render_window_while_menu_active(window);
     SDL_RenderPresent(window->renderer);
     window->next_redraw = SDL_GetTicks() + window->delay;
 }
 
 /* this function is mostly used while normally playing the game */
-static void redraw_window(struct window *window)
+static void redraw_window(struct sdlpui_window *window)
 {
-    if (window->status_bar.in_menu) {
-        /* we called (perhaps via refresh_angband_terms()) Term_fresh() in menu */
-        redraw_window_in_menu(window);
+    if (window->d_mouse || window->d_key) {
+        redraw_window_while_menu_active(window);
         return;
     }
 
-    /* XXX XXX dont forget to prerender status bar in loader! */
     render_all(window);
     SDL_RenderPresent(window->renderer);
     window->next_redraw = SDL_GetTicks() + window->delay;
 }
 
-static void try_redraw_window(struct window *window)
+static void try_redraw_window(struct sdlpui_window *window)
 {
     if (window->next_redraw < SDL_GetTicks()) {
         redraw_window(window);
     }
 }
 
-static void redraw_all_windows(bool dirty)
+static void redraw_all_windows(struct my_app *a, bool dirty)
 {
     for (unsigned i = 0; i < MAX_WINDOWS; i++) {
-        struct window *window = get_window_direct(i);
+        struct sdlpui_window *window = get_window_direct(a, i);
         if (window != NULL && (dirty ? window->dirty : true)) {
             render_status_bar(window);
             redraw_window(window);
@@ -912,23 +950,9 @@ static void redraw_all_windows(bool dirty)
     }
 }
 
-static void render_utf8_string(const struct window *window,
-        const struct font *font, SDL_Texture *dst_texture,
-        SDL_Color fg, SDL_Rect rect, const char *utf8_string)
-{
-    SDL_Surface *surface = TTF_RenderUTF8_Blended(font->ttf.handle, utf8_string, fg);
-    SDL_Texture *src_texture = SDL_CreateTextureFromSurface(window->renderer, surface);
-    SDL_FreeSurface(surface);
-
-    SDL_SetRenderTarget(window->renderer, dst_texture);
-    SDL_RenderCopy(window->renderer, src_texture, NULL, &rect);
-
-    SDL_DestroyTexture(src_texture);
-}
-
 /* this function is typically called in a loop, so for efficiency it doesn't
  * SetRenderTarget; caller must do it (but it does SetTextureColorMod) */
-static void render_glyph_mono(const struct window *window,
+static void render_glyph_mono(const struct sdlpui_window *window,
         const struct font *font, SDL_Texture *dst_texture,
         int x, int y, const SDL_Color *fg, uint16_t codepoint)
 {
@@ -985,7 +1009,7 @@ static void render_cursor_aux(struct subwindow *subwindow,
 static void render_cursor(struct subwindow *subwindow, 
         int col, int row, bool big)
 {
-    render_cursor_aux(subwindow, col, row, big, g_colors[DEFAULT_SUBWINDOW_CURSOR_COLOR]);
+    render_cursor_aux(subwindow, col, row, big, subwindow->app->colors[DEFAULT_SUBWINDOW_CURSOR_COLOR]);
 }
 
 static void render_grid_cell_text(const struct subwindow *subwindow,
@@ -1005,7 +1029,7 @@ static void render_grid_cell_text(const struct subwindow *subwindow,
     /* apparently either the same as a or obscured by a */
     (void) tc;
 
-    SDL_Color fg = g_colors[a % MAX_COLORS];
+    SDL_Color fg = subwindow->app->colors[a % MAX_COLORS];
     SDL_Color bg;
 
     switch (ta / MULT_BG) {
@@ -1016,11 +1040,11 @@ static void render_grid_cell_text(const struct subwindow *subwindow,
             bg = fg;
             break;
         case BG_DARK:
-            bg = g_colors[DEFAULT_SHADE_COLOR];
+            bg = subwindow->app->colors[DEFAULT_SHADE_COLOR];
             break;
         default:
             /* debugging */
-            bg = g_colors[DEFAULT_ERROR_COLOR];
+            bg = subwindow->app->colors[DEFAULT_ERROR_COLOR];
     }
 
     SDL_Rect rect = {
@@ -1135,7 +1159,7 @@ static void render_grid_cell_tile(const struct subwindow *subwindow,
     render_tile_rect_scaled(subwindow, x, y, tile, a, c);
 }
 
-static void clear_all_borders(struct window *window)
+static void clear_all_borders(struct sdlpui_window *window)
 {
     for (size_t i = 0; i < N_ELEMENTS(window->subwindows); i++) {
         struct subwindow *subwindow = window->subwindows[i];
@@ -1159,7 +1183,7 @@ static void render_borders(struct subwindow *subwindow)
             color = &subwindow->color;
         }
     } else {
-        color = &g_colors[DEFAULT_ERROR_COLOR];
+        color = &subwindow->app->colors[DEFAULT_ERROR_COLOR];
     }
 
     render_outline_rect_width(subwindow->window,
@@ -1167,7 +1191,8 @@ static void render_borders(struct subwindow *subwindow)
             subwindow->borders.width);
 }
 
-static SDL_Texture *make_subwindow_texture(const struct window *window, int w, int h)
+static SDL_Texture *make_subwindow_texture(const struct sdlpui_window *window,
+        int w, int h)
 {
     SDL_Texture *texture = SDL_CreateTexture(window->renderer,
             window->pixelformat, SDL_TEXTUREACCESS_TARGET, w, h);
@@ -1185,510 +1210,782 @@ static SDL_Texture *make_subwindow_texture(const struct window *window, int w, i
     return texture;
 }
 
-static void render_menu_panel(const struct window *window, struct menu_panel *menu_panel)
+/**
+ * Return true if the given font (face and size) can be used for a subwindow.
+ *
+ * \param font is the font of interest.
+ * \param subwindow is the subwindow of the interest.
+ * \param sizing_rect will, if not NULL and the return value is true, be
+ * dereferenced and the sizes set to the dimensions of the bounding rectangle
+ * for the subwindow when using the given font.
+ */
+static bool is_usable_font_for_subwindow(const struct font *font,
+        const struct subwindow *subwindow, SDL_Rect *sizing_rect)
 {
-    if (menu_panel == NULL) {
+    SDL_Rect bounds = subwindow->full_rect;
+
+    if (!is_ok_col_row(subwindow, &bounds, font->ttf.glyph.w,
+            font->ttf.glyph.h)) {
+        int min_cols, min_rows;
+
+        if (subwindow->index == MAIN_SUBWINDOW) {
+            min_cols = MIN_COLS_MAIN;
+            min_rows = MIN_ROWS_MAIN;
+        } else {
+            min_cols = MIN_COLS_OTHER;
+            min_rows = MIN_ROWS_OTHER;
+        }
+
+        bounds.w = min_cols * font->ttf.glyph.w + 2 * DEFAULT_BORDER;
+        bounds.h = min_rows * font->ttf.glyph.h + 2 * DEFAULT_BORDER;
+    }
+
+    if (bounds.w > subwindow->window->inner_rect.w
+            || bounds.h > subwindow->window->inner_rect.h)
+    {
+        return false;
+    }
+
+    if (sizing_rect) {
+        *sizing_rect = bounds;
+    }
+    return true;
+}
+
+/**
+ * Calculate the range of font sizes that can be used for a subwindow.
+ *
+ * \param subwindow is the subwindow to use.
+ * \param font is the font of interest.  If NULL, the current font for the
+ * subwindow is used.
+ * \param min_size is set to the minimum point size that can be used.  If
+ * the font is not a vector font, this will be set to zero.
+ * \param max_size is set to one past the maximum point size that can be used.
+ * If no size works, *max_size will be the same as *min_size when the function
+ * returns.  If the font is not a vector font and the subwindow can use the
+ * font, *max_size will be one.
+ */
+static void calculate_subwindow_font_size_bounds(struct subwindow *subwindow,
+        const struct font_info *font, int *min_size, int *max_size)
+{
+    struct font *trial_font;
+    int lo, hi;
+
+    if (!font) {
+        assert(subwindow->font);
+        font = &subwindow->app->fonts[subwindow->font->index];
+    }
+
+    if (font->type != FONT_TYPE_VECTOR) {
+        *min_size = 0;
+        trial_font = make_font(subwindow->window, font->name, 0);
+        if (is_usable_font_for_subwindow(trial_font, subwindow, NULL)) {
+            *max_size = 1;
+        } else {
+            *max_size = 0;
+        }
+        free_font(trial_font);
         return;
     }
 
-    for (size_t i = 0; i < menu_panel->button_bank.number; i++) {
-        struct button *button = &menu_panel->button_bank.buttons[i];
+    /* Find the smallest size that works. */
+    lo = MIN_VECTOR_FONT_SIZE;
+    while (1) {
+        if (lo > MAX_VECTOR_FONT_SIZE) {
+            /* No size works */
+            *min_size = DEFAULT_VECTOR_FONT_SIZE;
+            *max_size = DEFAULT_VECTOR_FONT_SIZE;
+            return;
+        }
+        trial_font = make_font(subwindow->window, font->name, lo);
+        if (is_usable_font_for_subwindow(trial_font, subwindow, NULL)) {
+            free_font(trial_font);
+            *min_size = lo;
+            break;
+        }
+        free_font(trial_font);
+        ++lo;
+    }
 
-        assert(button->callbacks.on_render != NULL);
-        button->callbacks.on_render(window, button);
-        if (button->disabled) {
-            stipple_button(window, button, NULL);
+    /* Find the largest size that works using a binary search. */
+    lo = *min_size;
+    hi = MAX_VECTOR_FONT_SIZE + 1;
+    while (1) {
+        int try;
+
+        if (lo == hi - 1) {
+            *max_size = lo;
+            return;
+        }
+        try = (lo + hi) / 2;
+        trial_font = make_font(subwindow->window, font->name, try);
+        if (is_usable_font_for_subwindow(trial_font, subwindow, NULL)) {
+            lo = try;
+        } else {
+            hi = try;
+        }
+        free_font(trial_font);
+    }
+}
+
+static bool handle_shortcut_editor_key(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_KeyboardEvent *e)
+{
+    struct shortcut_editor_data *pse;
+    keycode_t ch;
+    uint8_t mods;
+
+    SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
+    pse = d->priv;
+    if (pse->changing_shortcut == -1) {
+        return sdlpui_dialog_handle_key(d, w, e);
+    }
+    keyboard_event_to_angband_key(e, w->app->kp_as_mod, &ch, &mods);
+    if (ch) {
+        char keypress_desc[40];
+
+        SDL_assert(pse->changing_shortcut >= 0
+            && pse->changing_shortcut < MAX_WINDOWS);
+        w->app->menu_shortcuts[pse->changing_shortcut].type = EVT_KBRD;
+        w->app->menu_shortcuts[pse->changing_shortcut].code = ch;
+        w->app->menu_shortcuts[pse->changing_shortcut].mods = mods;
+        keypress_to_text(keypress_desc, sizeof(keypress_desc),
+            &w->app->menu_shortcuts[pse->changing_shortcut], true);
+        sdlpui_change_caption(
+            &pse->shortcut_displays[pse->changing_shortcut],
+            d, w, keypress_desc);
+        pse->changing_shortcut = -1;
+        sdlpui_change_caption(&pse->prompt_label, d, w, " ");
+        return true;
+    }
+    return false;
+}
+
+static bool handle_shortcut_editor_textin(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_TextInputEvent *e)
+{
+    struct shortcut_editor_data *pse;
+    keycode_t ch;
+    uint8_t mods;
+
+    SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
+    pse = d->priv;
+    if (pse->changing_shortcut == -1) {
+        return sdlpui_dialog_handle_textin(d, w, e);
+    }
+    textinput_event_to_angband_key(e, w->app->kp_as_mod, &ch, &mods);
+    if (ch) {
+        char keypress_desc[40];
+
+        SDL_assert(pse->changing_shortcut >= 0
+            && pse->changing_shortcut < MAX_WINDOWS);
+        w->app->menu_shortcuts[pse->changing_shortcut].type = EVT_KBRD;
+        w->app->menu_shortcuts[pse->changing_shortcut].code = ch;
+        w->app->menu_shortcuts[pse->changing_shortcut].mods = mods;
+        keypress_to_text(keypress_desc, sizeof(keypress_desc),
+            &w->app->menu_shortcuts[pse->changing_shortcut], true);
+        sdlpui_change_caption(
+            &pse->shortcut_displays[pse->changing_shortcut],
+            d, w, keypress_desc);
+        pse->changing_shortcut = -1;
+        sdlpui_change_caption(&pse->prompt_label, d, w, " ");
+        return true;
+    }
+    return false;
+}
+
+static void render_shortcut_editor(struct sdlpui_dialog *d,
+        struct sdlpui_window *w)
+{
+    struct SDL_Renderer *r = sdlpui_get_renderer(w);
+    SDL_Rect dst_r = d->rect;
+    struct shortcut_editor_data *pse;
+    const SDL_Color *color;
+    int i;
+
+    SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
+    pse = d->priv;
+    SDLPUI_RENDER_TRACER("shortcut editor", d, "(not extracted)", d->rect,
+        d->rect, d->texture);
+
+    SDL_SetRenderTarget(r, d->texture);
+    color = sdlpui_get_color(w, SDLPUI_COLOR_DIALOG_BG);
+    SDL_SetRenderDrawColor(r, color->r, color->g, color->b, color->a);
+    if (d->texture) {
+        dst_r.x = 0;
+        dst_r.y = 0;
+        SDL_RenderClear(r);
+    } else {
+        SDL_RenderFillRect(r, &dst_r);
+    }
+    for (i = 0; i < MAX_WINDOWS; ++i) {
+        if (pse->labels[i].ftb->render) {
+            (*pse->labels[i].ftb->render)(&pse->labels[i], d, w, r);
+        }
+        if (pse->shortcut_displays[i].ftb->render) {
+            (*pse->shortcut_displays[i].ftb->render)(
+                &pse->shortcut_displays[i], d, w, r);
+        }
+        if (pse->change_buttons[i].ftb->render) {
+            (*pse->change_buttons[i].ftb->render)(
+                &pse->change_buttons[i], d, w, r);
+        }
+        if (pse->clear_buttons[i].ftb->render) {
+            (*pse->clear_buttons[i].ftb->render)(
+                &pse->clear_buttons[i], d, w, r);
         }
     }
-    render_outline_rect(window,
-            NULL, &menu_panel->rect, &g_colors[DEFAULT_MENU_PANEL_OUTLINE_COLOR]);
-
-    /* recurse */
-    render_menu_panel(window, menu_panel->next);
-}
-
-static SDL_Rect get_button_caption_rect(const struct button *button)
-{
-    SDL_Rect rect = {
-        button->full_rect.x + button->inner_rect.x,
-        button->full_rect.y + button->inner_rect.y,
-        button->inner_rect.w,
-        button->inner_rect.h
-    };
-
-    return rect;
-}
-
-static void render_button_menu(const struct window *window,
-        struct button *button, const SDL_Color *fg, const SDL_Color *bg)
-{
-    SDL_Rect rect = get_button_caption_rect(button);
-
-    render_fill_rect(window,
-            NULL, &button->full_rect, bg);
-    render_utf8_string(window, window->status_bar.font, NULL, 
-            *fg, rect, button->caption);
-}
-
-static void render_button_menu_toggle(const struct window *window,
-        struct button *button, bool active)
-{
-    SDL_Color *bg;
-    SDL_Color *fg;
-
-    if (active) {
-        fg = &g_colors[DEFAULT_MENU_TOGGLE_FG_ACTIVE_COLOR];
-    } else {
-        fg = &g_colors[DEFAULT_MENU_TOGGLE_FG_INACTIVE_COLOR];
+    if (pse->prompt_label.ftb->render) {
+        (*pse->prompt_label.ftb->render)(&pse->prompt_label, d, w, r);
     }
-    if (button->highlighted) {
-        bg = &g_colors[DEFAULT_MENU_BG_ACTIVE_COLOR];
-    } else {
-        bg = &g_colors[DEFAULT_MENU_BG_INACTIVE_COLOR];
+    if (pse->close_button.ftb->render) {
+        (*pse->close_button.ftb->render)(&pse->close_button, d, w, r);
     }
-
-    render_button_menu(window, button, fg, bg);
+    if (pse->reset_button.ftb->render) {
+        (*pse->reset_button.ftb->render)(&pse->reset_button, d, w, r);
+    }
+    d->dirty = false;
 }
 
-static void render_button_menu_simple(const struct window *window, struct button *button)
+static void goto_shortcut_editor_first_control(struct sdlpui_dialog *d,
+        struct sdlpui_window *w)
 {
-    SDL_Color *fg;
-    SDL_Color *bg;
+    struct shortcut_editor_data *pse;
 
-    if (button->highlighted) {
-        fg = &g_colors[DEFAULT_MENU_FG_ACTIVE_COLOR];
-        bg = &g_colors[DEFAULT_MENU_BG_ACTIVE_COLOR];
-    } else {
-        fg = &g_colors[DEFAULT_MENU_FG_INACTIVE_COLOR];
-        bg = &g_colors[DEFAULT_MENU_BG_INACTIVE_COLOR];
-    }
-
-    render_button_menu(window, button, fg, bg);
+    SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
+    pse = d->priv;
+    SDL_assert(pse->change_buttons[0].ftb->gain_key);
+    SDL_assert(!d->c_key || d->c_key == &pse->change_buttons[0]);
+    (*pse->change_buttons[0].ftb->gain_key)(
+        &pse->change_buttons[0], d, w, 0);
+    d->c_key = &pse->change_buttons[0];
+    sdlpui_dialog_gain_key_focus(w, d);
 }
 
-static void render_button_menu_pw(const struct window *window, struct button *button)
+static void step_shortcut_editor_control(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, struct sdlpui_control *c, bool forward)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_TERM_FLAG);
-
-    struct subwindow *subwindow = button->data.value.term_flag_value.subwindow;
-    uint32_t flag = button->data.value.term_flag_value.flag;
-
-    assert(subwindow->index != MAIN_SUBWINDOW);
-    assert(subwindow->index < N_ELEMENTS(window_flag));
-
-    render_button_menu_toggle(window,
-            button, window_flag[subwindow->index] & flag);
-}
-
-static void render_button_menu_terms(const struct window *window, struct button *button)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_SUBWINDOW);
-
-    if (button->highlighted) {
-        /* draw a border around subwindow, so that it would be easy to see
-         * which subwindow corresponds to that button */
-        struct subwindow *subwindow = button->data.value.subwindow_value;
-        int outline_width = (subwindow->full_rect.w - subwindow->inner_rect.w) / 2
-                - subwindow->borders.width;
-        SDL_Rect outline_rect = subwindow->full_rect;
-        resize_rect(&outline_rect,
-                subwindow->borders.width, subwindow->borders.width,
-                -subwindow->borders.width, -subwindow->borders.width);
-        render_outline_rect_width(window,
-                NULL,
-                &outline_rect,
-                &g_colors[DEFAULT_SUBWINDOW_BORDER_COLOR],
-                outline_width);
-    }
-
-    render_button_menu_simple(window, button);
-}
-
-static void render_button_menu_borders(const struct window *window, struct button *button)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_SUBWINDOW);
-
-    struct subwindow *subwindow = button->data.value.subwindow_value;
-
-    render_button_menu_toggle(window, button, subwindow->borders.visible);
-}
-
-static void render_button_menu_alpha(const struct window *window, struct button *button)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_ALPHA);
-
-    struct subwindow *subwindow = button->data.value.alpha_value.subwindow;
-    int alpha = button->data.value.alpha_value.real_value;
-
-    SDL_Color fg;
-    SDL_Color *bg;
-
-    if (is_close_to(alpha, subwindow->color.a, DEFAULT_ALPHA_STEP / 2)) {
-        fg = g_colors[DEFAULT_MENU_TOGGLE_FG_ACTIVE_COLOR];
-    } else {
-        fg = g_colors[DEFAULT_MENU_TOGGLE_FG_INACTIVE_COLOR];
-    }
-    if (button->highlighted) {
-        bg = &g_colors[DEFAULT_MENU_BG_ACTIVE_COLOR];
-    } else {
-        bg = &g_colors[DEFAULT_MENU_BG_INACTIVE_COLOR];
-    }
-
-    SDL_Rect rect = get_button_caption_rect(button);
-
-    render_fill_rect(window,
-            NULL, &button->full_rect, bg);
-    render_utf8_string(window, window->status_bar.font, NULL, 
-            fg, rect, format(button->caption, button->data.value.alpha_value.show_value));
-}
-
-static void render_button_menu_top(const struct window *window, struct button *button)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_SUBWINDOW);
-
-    struct subwindow *subwindow = button->data.value.subwindow_value;
-
-    render_button_menu_toggle(window, button, subwindow->always_top);
-}
-
-static void render_button_menu_tile_size(const struct window *window,
-        struct button *button)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_INT);
-
-    assert(button->data.value.int_value == BUTTON_TILE_SIZE_WIDTH
-            || button->data.value.int_value == BUTTON_TILE_SIZE_HEIGHT);
-
-    SDL_Color fg;
-    SDL_Color *bg;
-
-    fg = g_colors[DEFAULT_MENU_TOGGLE_FG_ACTIVE_COLOR];
-    if (button->highlighted) {
-        bg = &g_colors[DEFAULT_MENU_BG_ACTIVE_COLOR];
-    } else {
-        bg = &g_colors[DEFAULT_MENU_BG_INACTIVE_COLOR];
-    }
-
-    SDL_Rect rect = get_button_caption_rect(button);
-
-    int scale = 0;
-    if (button->data.value.int_value == BUTTON_TILE_SIZE_WIDTH) {
-        scale = tile_width;
-    } else if (button->data.value.int_value == BUTTON_TILE_SIZE_HEIGHT) {
-        scale = tile_height;
-    }
-
-    render_fill_rect(window,
-            NULL, &button->full_rect, bg);
-    render_utf8_string(window, window->status_bar.font, NULL, 
-            fg, rect, format(button->caption, scale));
-}
-
-static void render_button_menu_tile_set(const struct window *window, struct button *button)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_INT);
-
-    render_button_menu_toggle(window,
-            button, button->data.value.int_value == current_graphics_mode->grafID);
-}
-
-static void render_button_menu_font_size(const struct window *window,
-        struct button *button)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_FONT);
-
-    SDL_Color fg;
-    SDL_Color *bg;
-
-    struct font_value font_value = button->data.value.font_value;
-
-    if (!font_value.size_ok) {
-        fg = g_colors[DEFAULT_ERROR_COLOR];
-    } else if (g_font_info[font_value.index].type == FONT_TYPE_VECTOR) {
-        fg = g_colors[DEFAULT_MENU_TOGGLE_FG_ACTIVE_COLOR];
-    } else {
-        fg = g_colors[DEFAULT_MENU_TOGGLE_FG_INACTIVE_COLOR];
-    }
-    if (button->highlighted) {
-        bg = &g_colors[DEFAULT_MENU_BG_ACTIVE_COLOR];
-    } else {
-        bg = &g_colors[DEFAULT_MENU_BG_INACTIVE_COLOR];
-    }
-
-    SDL_Rect rect = get_button_caption_rect(button);
-
-    render_fill_rect(window,
-            NULL, &button->full_rect, bg);
-    render_utf8_string(window, window->status_bar.font, NULL, 
-            fg, rect, format(button->caption, font_value.subwindow->font->size));
-}
-
-static void render_button_menu_font_name(const struct window *window, struct button *button)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_FONT);
-
-    SDL_Color fg;
-    SDL_Color *bg;
-
-    struct subwindow *subwindow = button->data.value.font_value.subwindow;
-    size_t index = button->data.value.font_value.index;
-
-    if (!button->data.value.font_value.size_ok) {
-        fg = g_colors[DEFAULT_ERROR_COLOR];
-    } else if (subwindow->font->index == index) {
-        fg = g_colors[DEFAULT_MENU_TOGGLE_FG_ACTIVE_COLOR];
-    } else {
-        fg = g_colors[DEFAULT_MENU_TOGGLE_FG_INACTIVE_COLOR];
-    }
-    if (button->highlighted) {
-        bg = &g_colors[DEFAULT_MENU_BG_ACTIVE_COLOR];
-    } else {
-        bg = &g_colors[DEFAULT_MENU_BG_INACTIVE_COLOR];
-    }
-
-    SDL_Rect rect = get_button_caption_rect(button);
-
-    render_fill_rect(window,
-            NULL, &button->full_rect, bg);
-    render_utf8_string(window, window->status_bar.font, NULL, 
-            fg, rect, button->caption);
-}
-
-static void render_button_menu_sound_volume(const struct window *window,
-        struct button *button)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_INT);
-
-    assert(button->data.value.int_value == BUTTON_VOLUME_SOUND
-            || button->data.value.int_value == BUTTON_VOLUME_MUSIC);
-
-    SDL_Color fg;
-    SDL_Color *bg;
-
-    fg = g_colors[DEFAULT_MENU_TOGGLE_FG_ACTIVE_COLOR];
-
-    if (button->highlighted) {
-        bg = &g_colors[DEFAULT_MENU_BG_ACTIVE_COLOR];
-    } else {
-        bg = &g_colors[DEFAULT_MENU_BG_INACTIVE_COLOR];
-    }
-
-    SDL_Rect rect = get_button_caption_rect(button);
-
-    int scale = 0;
-    if (button->data.value.int_value == BUTTON_VOLUME_SOUND) {
-        scale = sound_volume;
-    } else if (button->data.value.int_value == BUTTON_VOLUME_MUSIC) {
-        scale = music_volume;
-    }
-
-    render_fill_rect(window,
-            NULL, &button->full_rect, bg);
-    render_utf8_string(window, window->status_bar.font, NULL, 
-            fg, rect, format(button->caption, scale));
-}
-
-static void render_button_menu_window(const struct window *window,
-        struct button *button)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_UNSIGNED);
-
-    struct window *w = get_window_direct(button->data.value.unsigned_value);
-
-    SDL_Color fg;
-    SDL_Color *bg;
-
-    if (w != NULL) {
-        fg = g_colors[DEFAULT_MENU_TOGGLE_FG_ACTIVE_COLOR];
-    } else {
-        fg = g_colors[DEFAULT_MENU_TOGGLE_FG_INACTIVE_COLOR];
-    }
-    if (button->highlighted) {
-        bg = &g_colors[DEFAULT_MENU_BG_ACTIVE_COLOR];
-    } else {
-        bg = &g_colors[DEFAULT_MENU_BG_INACTIVE_COLOR];
-    }
-
-    SDL_Rect rect = get_button_caption_rect(button);
-
-    render_fill_rect(window, NULL, &button->full_rect, bg);
-    render_utf8_string(window, window->status_bar.font, NULL, 
-            fg, rect, format(button->caption, button->data.value.unsigned_value));
-}
-
-static void render_button_menu_fullscreen(const struct window *window,
-        struct button *button)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_NONE);
-
-    render_button_menu_toggle(window, button,
-            window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP);
-}
-
-static void render_button_menu_kp_mod(const struct window *window,
-        struct button *button)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_NONE);
-
-    render_button_menu_toggle(window, button, g_kp_as_mod);
-}
-
-/* the menu proper is rendered via this callback, used by the "Menu" button */
-static void render_menu_button(const struct window *window, struct button *button)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_NONE);
-
-    SDL_Color color;
-    if (button->highlighted) {
-        color = g_colors[DEFAULT_STATUS_BAR_BUTTON_ACTIVE_COLOR];
-    } else {
-        color = g_colors[DEFAULT_STATUS_BAR_BUTTON_INACTIVE_COLOR];
-    }
-
-    SDL_Rect rect = get_button_caption_rect(button);
-
-    render_utf8_string(window, window->status_bar.font, window->status_bar.texture, 
-            color, rect, button->caption);
-
-    if (button->highlighted) {
-        render_menu_panel(window, window->status_bar.menu_panel);
-    }
-}
-
-static void render_button_subwindows(const struct window *window, struct button *button)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_UNSIGNED);
-
-    SDL_Color color;
-    if (has_visible_subwindow(window, button->data.value.unsigned_value)
-            || button->highlighted) {
-        color = g_colors[DEFAULT_STATUS_BAR_BUTTON_ACTIVE_COLOR];
-    } else {
-        color = g_colors[DEFAULT_STATUS_BAR_BUTTON_INACTIVE_COLOR];
-    }
-
-    SDL_Rect rect = get_button_caption_rect(button);
-
-    render_utf8_string(window, window->status_bar.font, window->status_bar.texture, 
-            color, rect, button->caption);
-}
-
-static void render_button_movesize(const struct window *window, struct button *button)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_INT);
-
-    bool active = false;
-    switch (button->data.value.int_value) {
-        case BUTTON_MOVESIZE_MOVING:
-            active = window->move_state.active;
+    struct shortcut_editor_data *pse;
+    int i = 0;
+    struct sdlpui_control *new_c = NULL;
+
+    SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
+    pse = d->priv;
+    while (1) {
+        if (i >= MAX_WINDOWS) {
+            if (c == &pse->close_button) {
+                new_c = (forward) ?
+                    &pse->reset_button :
+                    &pse->clear_buttons[MAX_WINDOWS - 1];
+            } else if (c == &pse->reset_button) {
+                new_c = (forward) ?
+                    &pse->change_buttons[0] :
+                    &pse->close_button;
+            } else {
+                /*
+                 * c is not a button in the dialog.  Just go
+                 * to the first button.
+                 */
+                new_c = &pse->change_buttons[0];
+            }
             break;
-        case BUTTON_MOVESIZE_SIZING:
-            active = window->size_state.active;
+        }
+        if (c == &pse->change_buttons[i]) {
+            new_c = (forward) ? &pse->clear_buttons[i] :
+                ((i > 0) ? &pse->clear_buttons[i - 1] :
+                &pse->close_button);
             break;
-        default:
-            quit_fmt("button '%s' has wrong int_value %d",
-                    button->caption, button->data.value.int_value);
+        } else if (c == &pse->clear_buttons[i]) {
+            new_c = (forward) ? ((i < MAX_WINDOWS - 1) ?
+                &pse->change_buttons[i + 1] :
+                &pse->close_button) : &pse->change_buttons[i];
             break;
+        }
+        ++i;
+    }
+    SDL_assert(new_c->ftb->gain_key);
+    if (d->c_key && d->c_key != new_c &&
+            d->c_key->ftb->lose_key) {
+        (*d->c_key->ftb->lose_key)(d->c_key, d, w, false);
+    }
+    (*new_c->ftb->gain_key)(new_c, d, w, 0);
+    d->c_key = new_c;
+}
+
+static struct sdlpui_control *find_shortcut_editor_control_containing(
+        struct sdlpui_dialog* d, struct sdlpui_window *w, Sint32 x,
+        Sint32 y, int *comp_ind)
+{
+    struct shortcut_editor_data *pse;
+    struct sdlpui_control *c = NULL;
+
+    SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
+    pse = d->priv;
+
+    /* Make the coordinates relative to the dialog. */
+    x -= d->rect.x;
+    y -= d->rect.y;
+
+    *comp_ind = 0;
+    if (y < pse->close_button.rect.y) {
+        if (y >= pse->change_buttons[0].rect.y) {
+            int i = (y - pse->change_buttons[0].rect.y) /
+                (pse->change_buttons[1].rect.y
+                    - pse->change_buttons[0].rect.y);
+
+            if (i < MAX_WINDOWS && i >= 0
+                    && y >= pse->change_buttons[i].rect.y
+                    && y < pse->change_buttons[i].rect.y
+                    + pse->change_buttons[i].rect.h) {
+                if (x >= pse->change_buttons[i].rect.x
+                        && x < pse->change_buttons[i].rect.x
+                        + pse->change_buttons[i].rect.w) {
+                    c = &pse->change_buttons[i];
+                } else if (x >= pse->clear_buttons[i].rect.x
+                        && x < pse->clear_buttons[i].rect.x
+                        + pse->clear_buttons[i].rect.w) {
+                    c = &pse->clear_buttons[i];
+                }
+            }
+        }
+    } else if (y < pse->close_button.rect.y + pse->close_button.rect.h) {
+        if (x >= pse->close_button.rect.x
+                && x < pse->close_button.rect.x
+                    + pse->close_button.rect.w) {
+            c = &pse->close_button;
+        } else if (x >= pse->reset_button.rect.x
+                && x < pse->reset_button.rect.x
+                    + pse->reset_button.rect.w) {
+            c = &pse->reset_button;
+        }
+    }
+    return c;
+}
+
+static void resize_shortcut_editor(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int width, int height)
+{
+    struct shortcut_editor_data *pse;
+    int i, x, y, cw, ch, rowh;
+
+    SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
+    pse = d->priv;
+#ifdef NDEBUG
+    {
+        int dw, dh;
+
+        query_shortcut_editor_natural_size(d, w, &dw, &dh);
+        SDL_assert(width >= dw && height >= dh);
+    }
+#endif
+
+    y = 0;
+    for (i = 0; i < MAX_WINDOWS; ++i) {
+        x = 0;
+        rowh = 0;
+        (*pse->labels[i].ftb->query_natural_size)(&pse->labels[i], d, w,
+            &cw, &ch);
+        if (pse->labels[i].ftb->resize) {
+            (*pse->labels[i].ftb->resize)(&pse->labels[i], d, w,
+                cw, ch);
+        } else {
+            pse->labels[i].rect.w = cw;
+            pse->labels[i].rect.h = ch;
+        }
+        pse->labels[i].rect.x = x;
+        pse->labels[i].rect.y = y;
+        x += cw;
+        rowh = MAX(rowh, ch);
+
+        if (pse->shortcut_displays[i].ftb->resize) {
+            (*pse->shortcut_displays[i].ftb->resize)(
+                &pse->shortcut_displays[i], d, w, cw * 2, ch);
+        } else {
+            pse->shortcut_displays[i].rect.w = cw * 2;
+            pse->shortcut_displays[i].rect.h = ch;
+        }
+        pse->shortcut_displays[i].rect.x = x;
+        pse->shortcut_displays[i].rect.y = y;
+        x += cw * 2;
+
+        (*pse->change_buttons[i].ftb->query_natural_size)(
+            &pse->change_buttons[i], d, w, &cw, &ch);
+        if (pse->change_buttons[i].ftb->resize) {
+            (*pse->change_buttons[i].ftb->resize)(
+                &pse->change_buttons[i], d, w, cw, ch);
+        } else {
+            pse->change_buttons[i].rect.w = cw;
+            pse->change_buttons[i].rect.h = ch;
+        }
+        pse->change_buttons[i].rect.x = x;
+        pse->change_buttons[i].rect.y = y;
+        /*
+         * Leave 1/8 of the width as space between the change and clear
+         * buttons.
+         */
+        x += (9 * cw + 7) / 8;
+        rowh = MAX(rowh, ch);
+
+        (*pse->clear_buttons[i].ftb->query_natural_size)(
+            &pse->clear_buttons[i], d, w, &cw, &ch);
+        if (pse->clear_buttons[i].ftb->resize) {
+            (*pse->clear_buttons[i].ftb->resize)(
+                &pse->clear_buttons[i], d, w, cw, ch);
+        } else {
+            pse->clear_buttons[i].rect.w = cw;
+            pse->clear_buttons[i].rect.h = ch;
+        }
+        pse->clear_buttons[i].rect.x = x;
+        pse->clear_buttons[i].rect.y = y;
+        x += cw;
+        rowh = MAX(rowh, ch);
+
+        y += rowh;
     }
 
-    SDL_Color color;
-    if (active || button->highlighted) {
-        color = g_colors[DEFAULT_STATUS_BAR_BUTTON_ACTIVE_COLOR];
+    (*pse->prompt_label.ftb->query_natural_size)(&pse->prompt_label, d, w,
+        &cw, &ch);
+    SDL_assert(width >= cw);
+    if (pse->prompt_label.ftb->resize) {
+        (*pse->prompt_label.ftb->resize)(&pse->prompt_label, d, w,
+            width, ch);
     } else {
-        color = g_colors[DEFAULT_STATUS_BAR_BUTTON_INACTIVE_COLOR];
+        pse->prompt_label.rect.w = width;
+        pse->prompt_label.rect.h = ch;
     }
+    pse->prompt_label.rect.x = 0;
+    pse->prompt_label.rect.y = y;
+    y += ch;
 
-    SDL_Rect rect = get_button_caption_rect(button);
+    x = width / 8;
+    rowh = 0;
+    (*pse->close_button.ftb->query_natural_size)(&pse->close_button, d, w,
+        &cw, &ch);
+    SDL_assert(width >= cw * 4);
+    cw = MAX(cw, width / 4);
+    rowh = MAX(rowh, ch);
+    if (pse->close_button.ftb->resize) {
+        (*pse->close_button.ftb->resize)(
+            &pse->close_button, d, w, cw, ch);
+    } else {
+        pse->close_button.rect.w = cw;
+        pse->close_button.rect.h = ch;
+    }
+    pse->close_button.rect.x = x;
+    x += cw + width / 4;
+    (*pse->reset_button.ftb->query_natural_size)(&pse->reset_button, d, w,
+        &cw, &ch);
+    SDL_assert(width >= cw * 4);
+    cw = MAX(cw, width / 4);
+    rowh = MAX(rowh, ch);
+    if (pse->reset_button.ftb->resize) {
+        (*pse->reset_button.ftb->resize)(
+            &pse->reset_button, d, w, cw, ch);
+    } else {
+        pse->reset_button.rect.w = cw;
+        pse->reset_button.rect.h = ch;
+    }
+    pse->reset_button.rect.x = x;
+    SDL_assert(y + rowh <= height);
+    pse->close_button.rect.y = height - rowh;
+    pse->reset_button.rect.y = height - rowh;
 
-    render_utf8_string(window, window->status_bar.font, window->status_bar.texture, 
-            color, rect, button->caption);
+    d->rect.w = width;
+    d->rect.h = height;
 }
 
-static void show_about(const struct window *window)
+static void query_shortcut_editor_natural_size(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int *width, int *height)
 {
-    const char *about_text[] = {
-        version_build(VERSION_NAME, true),
-        "See http://www.rephial.org",
-        "Visit our forum at http://angband.oook.cz/forum"
-    };
+    struct shortcut_editor_data *pse;
+    int dw = 0, dh = 0, cw, ch, roww, rowh;
 
-    struct { SDL_Rect rect; const char *text; } elems[N_ELEMENTS(about_text)];
-    for (size_t i = 0; i < N_ELEMENTS(elems); i++) {
-        elems[i].text = about_text[i];
-    }
-
-    char path[4096];
-    path_build(path, sizeof(path), DEFAULT_ABOUT_ICON_DIR, DEFAULT_ABOUT_ICON);
-
-    SDL_Texture *texture = load_image(window, path);
-    SDL_Rect texture_rect = {0};
-    SDL_QueryTexture(texture, NULL, NULL, &texture_rect.w, &texture_rect.h);
-
-    SDL_Rect total = {
-        0, 0,
-        2 * DEFAULT_XTRA_BORDER + texture_rect.w,
-        /* the default icon just looks better without bottom border */
-        DEFAULT_XTRA_BORDER + texture_rect.h
-    };
-
-    for (size_t i = 0; i < N_ELEMENTS(elems); i++) {
-        int w;
-        int h;
-        get_string_metrics(window->status_bar.font,
-                elems[i].text, &w, &h);
-
-        elems[i].rect.h = h;
-        elems[i].rect.w = w;
-        elems[i].rect.y = total.h + (DEFAULT_LINE_HEIGHT(h) - h) / 2;
-
-        total.w = MAX(w + 2 * DEFAULT_XTRA_BORDER, total.w);
-        total.h += DEFAULT_LINE_HEIGHT(h);
-    }
-    total.h += DEFAULT_XTRA_BORDER;
-
-    total.x = window->full_rect.w / 2 - total.w / 2;
-    total.y = window->full_rect.h / 2 - total.h / 2;
-
-    render_window_in_menu(window);
-
-    render_fill_rect(window, NULL, &total, &g_colors[DEFAULT_ABOUT_BG_COLOR]);
-    render_outline_rect_width(window, NULL, &total,
-            &g_colors[DEFAULT_ABOUT_BORDER_OUTER_COLOR], DEFAULT_VISIBLE_BORDER);
-    resize_rect(&total,
-            DEFAULT_VISIBLE_BORDER, DEFAULT_VISIBLE_BORDER,
-            -DEFAULT_VISIBLE_BORDER, -DEFAULT_VISIBLE_BORDER);
-    render_outline_rect_width(window, NULL, &total,
-            &g_colors[DEFAULT_ABOUT_BORDER_INNER_COLOR], DEFAULT_VISIBLE_BORDER);
-
-    for (size_t i = 0; i < N_ELEMENTS(elems); i++) {
-        /* center the string in total rect */
-        elems[i].rect.x = total.x + (total.w - elems[i].rect.w) / 2;
-        /* make the y coord of string absolute (was relative to total rect) */
-        elems[i].rect.y += total.y;
-
-        render_utf8_string(window, window->status_bar.font,
-            NULL, g_colors[DEFAULT_ABOUT_TEXT_COLOR],
-            elems[i].rect, elems[i].text);
-    }
-
-    texture_rect.x = total.x + (total.w - texture_rect.w) / 2;
-    texture_rect.y = total.y + DEFAULT_XTRA_BORDER;
-
-    SDL_SetRenderTarget(window->renderer, NULL);
-    SDL_RenderCopy(window->renderer, texture, NULL, &texture_rect);
-    SDL_RenderPresent(window->renderer);
-
-    wait_anykey();
-
-    SDL_DestroyTexture(texture);
+    SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
+    pse = d->priv;
+    (*pse->labels[0].ftb->query_natural_size)(&pse->labels[0],
+        d, w, &roww, &rowh);
+    /*
+     * The shortcut display will be three times the width of the label that
+     * precedes it.
+     */
+    roww *= 3;
+    (*pse->change_buttons[0].ftb->query_natural_size)(
+        &pse->change_buttons[0], d, w, &cw, &ch);
+    /*
+     * Leave 1/8 of the width (rounded up) as space between the change and
+     * clear buttons.
+     */
+    roww += (9 * cw + 7) / 8;
+    rowh = MAX(rowh, ch);
+    (*pse->clear_buttons[0].ftb->query_natural_size)(&pse->clear_buttons[0],
+        d, w, &cw, &ch);
+    roww += cw;
+    rowh = MAX(rowh, ch);
+    dw = MAX(dw, roww);
+    dh += MAX_WINDOWS * rowh;
+    (*pse->close_button.ftb->query_natural_size)(&pse->close_button,
+        d, w, &roww, &rowh);
+    (*pse->reset_button.ftb->query_natural_size)(&pse->reset_button,
+        d, w, &cw, &ch);
+    roww = 4 * MAX(roww, cw);
+    rowh = MAX(rowh, ch);
+    dw = MAX(dw, roww);
+    /*
+     * Leave space between the buttons at the bottom of the dialog and the
+     * rest.
+     */
+    dh += 3 * rowh;
+    *width = dw;
+    *height = dh;
 }
 
-static void signal_move_state(struct window *window)
+static void cleanup_shortcut_editor(struct sdlpui_dialog *d)
 {
-    assert(!window->size_state.active);
+    struct shortcut_editor_data *pse;
+    int i;
 
+    SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
+    pse = d->priv;
+    for (i = 0; i < MAX_WINDOWS; ++i) {
+        if (pse->labels[i].ftb->cleanup) {
+            (*pse->labels[i].ftb->cleanup)(&pse->labels[i]);
+        }
+        if (pse->shortcut_displays[i].ftb->cleanup) {
+            (*pse->shortcut_displays[i].ftb->cleanup)(
+                &pse->shortcut_displays[i]);
+        }
+        if (pse->change_buttons[i].ftb->cleanup) {
+            (*pse->change_buttons[i].ftb->cleanup)(
+                &pse->change_buttons[i]);
+        }
+        if (pse->clear_buttons[i].ftb->cleanup) {
+            (*pse->clear_buttons[i].ftb->cleanup)(
+                &pse->clear_buttons[i]);
+        }
+    }
+    if (pse->prompt_label.ftb->cleanup) {
+        (*pse->prompt_label.ftb->cleanup)(&pse->prompt_label);
+    }
+    if (pse->close_button.ftb->cleanup) {
+        (*pse->close_button.ftb->cleanup)(&pse->close_button);
+    }
+    if (pse->reset_button.ftb->cleanup) {
+        (*pse->reset_button.ftb->cleanup)(&pse->reset_button);
+    }
+    SDL_free(pse);
+}
+
+static void handle_shortcut_change(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w)
+{
+    struct shortcut_editor_data *pse;
+    int tag = sdlpui_get_tag(c);
+
+    SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
+    pse = d->priv;
+    SDL_assert(tag >= 0 && tag < MAX_WINDOWS);
+    pse->changing_shortcut = tag;
+    sdlpui_change_caption(&pse->prompt_label, d, w,
+        format("Press key combination for window %d's new shortcut",
+        tag + 1));
+}
+
+static void handle_shortcut_clear(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w)
+{
+    struct shortcut_editor_data *pse;
+    int tag = sdlpui_get_tag(c);
+
+    SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
+    pse = d->priv;
+    SDL_assert(tag >= 0 && tag < MAX_WINDOWS);
+    if (w->app->menu_shortcuts[tag].type != EVT_NONE) {
+        w->app->menu_shortcuts[tag].type = EVT_NONE;
+        w->app->menu_shortcuts[tag].code = 0;
+        w->app->menu_shortcuts[tag].mods = 0;
+        sdlpui_change_caption(&pse->shortcut_displays[tag], d, w,
+            "None");
+    }
+    if (pse->changing_shortcut != -1) {
+        /* Reset to no prompt for a keystroke. */
+        pse->changing_shortcut = -1;
+        sdlpui_change_caption(&pse->prompt_label, d, w, " ");
+    }
+}
+
+static void handle_shortcut_editor_close(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w)
+{
+    sdlpui_popdown_dialog(d, w, false);
+}
+
+static void handle_shortcut_editor_reset(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w)
+{
+    struct shortcut_editor_data *pse;
+    int i;
+
+    SDL_assert(d->type_code == SHORTCUT_EDITOR_CODE && d->priv);
+    pse = d->priv;
+    for (i = 0; i < MAX_WINDOWS; ++i) {
+        if (w->app->menu_shortcuts[i].type == EVT_NONE) {
+            continue;
+        }
+        w->app->menu_shortcuts[i].type = EVT_NONE;
+        w->app->menu_shortcuts[i].code = 0;
+        w->app->menu_shortcuts[i].mods = 0;
+        sdlpui_change_caption(&pse->shortcut_displays[i], d, w, "None");
+    }
+    if (pse->changing_shortcut != -1) {
+        /* Reset to no prompt for a keystroke. */
+        pse->changing_shortcut = -1;
+        sdlpui_change_caption(&pse->prompt_label, d, w, " ");
+    }
+}
+
+static void hide_shortcut_editor(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, bool up)
+{
+    if (!up) {
+        SDL_assert(w->shorte == d);
+        w->shorte = NULL;
+    }
+}
+
+static void show_shortcut_editor(struct sdlpui_window *w, int x, int y)
+{
+    static const struct sdlpui_dialog_funcs shortcut_editor_funcs = {
+        handle_shortcut_editor_key,
+        handle_shortcut_editor_textin,
+        NULL,
+        sdlpui_dialog_handle_mouseclick,
+        sdlpui_dialog_handle_mousemove,
+        sdlpui_dialog_handle_mousewheel,
+        sdlpui_dialog_handle_loses_mouse,
+        sdlpui_dialog_handle_loses_key,
+        sdlpui_dialog_handle_window_loses_mouse,
+        sdlpui_dialog_handle_window_loses_key,
+        render_shortcut_editor,
+        NULL,
+        goto_shortcut_editor_first_control,
+        step_shortcut_editor_control,
+        find_shortcut_editor_control_containing,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        resize_shortcut_editor,
+        query_shortcut_editor_natural_size,
+        NULL,
+        cleanup_shortcut_editor
+    };
+    struct shortcut_editor_data *pse;
+    int i;
+    int dw, dh;
+
+    if (w->shorte) {
+        sdlpui_popup_dialog(w->shorte, w, true);
+        return;
+    }
+    w->shorte = SDL_malloc(sizeof(*w->shorte));
+    pse = SDL_malloc(sizeof(*pse));
+    for (i = 0; i < MAX_WINDOWS; ++i) {
+        char keypress_desc[40];
+
+        sdlpui_create_label(&pse->labels[i],
+            format("Window %d menu", i + 1),  SDLPUI_HOR_LEFT);
+        if (w->app->menu_shortcuts[i].type == EVT_KBRD) {
+            keypress_to_text(keypress_desc, sizeof(keypress_desc),
+                &w->app->menu_shortcuts[i], true);
+        } else {
+            (void)my_strcpy(keypress_desc, "None",
+                sizeof(keypress_desc));
+        }
+        sdlpui_create_label(&pse->shortcut_displays[i], keypress_desc,
+            SDLPUI_HOR_LEFT);
+        sdlpui_create_push_button(&pse->change_buttons[i],
+            "Change", SDLPUI_HOR_CENTER, handle_shortcut_change,
+            i, false);
+        sdlpui_create_push_button(&pse->clear_buttons[i],
+            "Clear", SDLPUI_HOR_CENTER, handle_shortcut_clear,
+            i, false);
+    }
+    sdlpui_create_label(&pse->prompt_label, "", SDLPUI_HOR_CENTER);
+    sdlpui_create_push_button(&pse->close_button, "Close",
+        SDLPUI_HOR_CENTER, handle_shortcut_editor_close, 0, false);
+    sdlpui_create_push_button(&pse->reset_button, "Reset",
+        SDLPUI_HOR_CENTER, handle_shortcut_editor_reset, 0,
+        false);
+    pse->changing_shortcut = -1;
+
+    w->shorte->ftb = &shortcut_editor_funcs;
+    w->shorte->pop_callback = hide_shortcut_editor;
+    w->shorte->next = NULL;
+    w->shorte->prev = NULL;
+    w->shorte->texture = NULL;
+    w->shorte->c_mouse = NULL;
+    w->shorte->c_key = NULL;
+    w->shorte->priv = pse;
+    w->shorte->type_code = SHORTCUT_EDITOR_CODE;
+    w->shorte->tag = 0;
+    w->shorte->pinned = false;
+    w->shorte->dirty = true;
+
+    (*w->shorte->ftb->query_natural_size)(w->shorte, w, &dw, &dh);
+    if (w->shorte->ftb->resize) {
+        (*w->shorte->ftb->resize)(w->shorte, w, dw, dh);
+    } else {
+        w->shorte->rect.w = dw;
+        w->shorte->rect.h = dh;
+    }
+    w->shorte->rect.x = x;
+    w->shorte->rect.y = y;
+    sdlpui_popup_dialog(w->shorte, w, true);
+}
+
+static void hide_about(struct sdlpui_dialog *d, struct sdlpui_window *w,
+        bool up)
+{
+    if (!up) {
+        SDL_assert(w->infod == d);
+        w->infod = NULL;
+    }
+}
+
+static void show_about(struct sdlpui_window *window, int x, int y)
+{
+    if (!window->infod) {
+        char path[4096];
+        SDL_Texture *texture;
+
+        window->infod = sdlpui_start_simple_info("Ok", NULL, 0);
+        path_build(path, sizeof(path), DEFAULT_ABOUT_ICON_DIR,
+            DEFAULT_ABOUT_ICON);
+        texture = load_image(window, path);
+        sdlpui_simple_info_add_image(window->infod, texture,
+            SDLPUI_HOR_CENTER, DEFAULT_XTRA_BORDER, 0,
+            DEFAULT_XTRA_BORDER, DEFAULT_XTRA_BORDER);
+        sdlpui_simple_info_add_label(window->infod,
+            version_build(VERSION_NAME, true),
+            SDLPUI_HOR_CENTER);
+        sdlpui_simple_info_add_label(window->infod,
+            "See http://www.rephial.org", SDLPUI_HOR_CENTER);
+        sdlpui_simple_info_add_label(window->infod,
+            "Visit our forum at http://angband.oook.cz/forum",
+            SDLPUI_HOR_CENTER);
+        sdlpui_complete_simple_info(window->infod, window);
+        window->infod->pop_callback = hide_about;
+        window->infod->rect.x = x;
+        window->infod->rect.y = y;
+    }
+    sdlpui_popup_dialog(window->infod, window, true);
+}
+
+static void signal_move_state(struct sdlpui_window *window)
+{
     bool was_active = window->move_state.active;
 
+    SDL_assert(!window->size_state.active);
     if (was_active) {
         window->move_state.active = false;
         window->move_state.moving = false;
@@ -1696,1174 +1993,902 @@ static void signal_move_state(struct window *window)
     } else {
         window->move_state.active = true;
     }
+    if (window->move_button) {
+        struct sdlpui_menu_button *mb;
 
-    SDL_SetWindowGrab(window->window,
-            was_active ? SDL_FALSE : SDL_TRUE);
+        SDL_assert(window->move_button->type_code
+            == SDLPUI_CTRL_MENU_BUTTON);
+        mb = (struct sdlpui_menu_button*)window->move_button->priv;
+        SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
+        mb->v.toggled = window->move_state.active;
+        window->status_bar->dirty = true;
+    }
+
+    SDL_SetWindowGrab(window->window, was_active ? SDL_FALSE : SDL_TRUE);
     window->alpha = was_active ? DEFAULT_ALPHA_FULL : DEFAULT_ALPHA_LOW;
 }
 
-static void signal_size_state(struct window *window)
+static void signal_size_state(struct sdlpui_window *window)
 {
-    assert(!window->move_state.active);
-
     bool was_active = window->size_state.active;
 
+    SDL_assert(!window->move_state.active);
     if (was_active) {
         window->size_state.active = false;
         window->size_state.sizing = false;
         if (window->size_state.subwindow != NULL) {
-            memset(&window->size_state.subwindow->sizing_rect,
-                    0, sizeof(window->size_state.subwindow->sizing_rect));
+            memset(&window->size_state.subwindow->sizing_rect, 0,
+                sizeof(window->size_state.subwindow->sizing_rect));
             window->size_state.subwindow = NULL;
         }
     } else {
         window->size_state.active = true;
     }
+    if (window->size_button) {
+        struct sdlpui_menu_button *mb;
 
-    SDL_SetWindowGrab(window->window,
-            was_active ? SDL_FALSE : SDL_TRUE);
+        SDL_assert(window->size_button->type_code
+            == SDLPUI_CTRL_MENU_BUTTON);
+        mb = (struct sdlpui_menu_button*)window->size_button->priv;
+        SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
+        mb->v.toggled = window->size_state.active;
+        window->status_bar->dirty = true;
+    }
+
+    SDL_SetWindowGrab(window->window, was_active ? SDL_FALSE : SDL_TRUE);
     window->alpha = was_active ? DEFAULT_ALPHA_FULL : DEFAULT_ALPHA_LOW;
 }
 
-static bool ignore_status_bar_button(struct window *window,
-        struct button *button, const SDL_Event *event)
+static void handle_button_movesize(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    (void) window;
-    (void) button;
-    (void) event;
-
-    return false;
-}
-
-static bool click_status_bar_button(struct window *window,
-        struct button *button, const SDL_Event *event)
-{
-    switch (event->type) {
-        case SDL_MOUSEBUTTONDOWN:
-            if (is_point_in_rect(event->button.x, event->button.y, &button->full_rect)) {
-                button->selected = true;
-                return false;
-            }
-            break;
-        case SDL_MOUSEBUTTONUP:
-            if (is_point_in_rect(event->button.x, event->button.y, &button->full_rect)
-                    && button->selected)
-            {
-                button->selected = false;
-                return true;
-            }
-            break;
-        case SDL_MOUSEMOTION:
-            if (is_point_in_rect(event->motion.x, event->motion.y, &button->full_rect)) {
-                button->highlighted = true;
-                return false;
-            }
-            break;
-    }
-
-    button->highlighted = false;
-    button->selected = false;
-
-    return false;
-}
-
-static bool handle_button_movesize(struct window *window,
-        struct button *button, const SDL_Event *event)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_INT);
-
-    if (!click_status_bar_button(window, button, event)) {
-        return false;
-    }
-
-    switch (button->data.value.int_value) {
-        case BUTTON_MOVESIZE_MOVING:
-            if (window->size_state.active) {
-                /* toggle size button */
-                signal_size_state(window);
-            }
-            signal_move_state(window);
-            break;
-        case BUTTON_MOVESIZE_SIZING:
-            if (window->move_state.active) {
-                /* toggle move button */
-                signal_move_state(window);
-            }
+    SDL_assert(ctrl->ftb->get_tag);
+    if ((*ctrl->ftb->get_tag)(ctrl) == 0) {
+        if (window->size_state.active) {
+            /* toggle size button */
             signal_size_state(window);
-            break;
-    }
-
-    return true;
-}
-
-static void push_button(struct button_bank *bank, struct font *font,
-        const char *caption, bool disabled, struct button_data data, struct button_callbacks callbacks,
-        const SDL_Rect *rect, enum button_caption_position position)
-{
-    assert(bank->number < bank->size);
-
-    struct button *button = &bank->buttons[bank->number];
-
-    int w;
-    int h;
-    get_string_metrics(font, caption, &w, &h);
-
-    int x = 0;
-    switch (position) {
-        case CAPTION_POSITION_CENTER:
-            x = (rect->w - w) / 2;
-            break;
-        case CAPTION_POSITION_LEFT:
-            x = DEFAULT_BUTTON_BORDER;
-            break;
-        case CAPTION_POSITION_RIGHT:
-            x = rect->w - DEFAULT_BUTTON_BORDER - w;
-            break;
-        default:
-            quit_fmt("bad caption position %d in button '%s'",
-                    position, button->caption);
-            break;
-    }
-
-    button->inner_rect.x = x;
-    button->inner_rect.y = (rect->h - h) / 2;
-    button->inner_rect.w = w;
-    button->inner_rect.h = h;
-
-    button->full_rect = *rect;
-
-    assert(button->full_rect.w >= button->inner_rect.w
-            && button->full_rect.h >= button->inner_rect.h);
-
-    button->caption = string_make(caption);
-
-    button->callbacks = callbacks;
-    button->data = data;
-    button->disabled = disabled;
-    button->highlighted = false;
-    button->selected = false;
-
-    bank->number++;
-}
-
-static struct menu_panel *new_menu_panel(void)
-{
-    struct menu_panel *menu = mem_zalloc(sizeof(*menu));
-
-    make_button_bank(&menu->button_bank);
-    menu->next = NULL;
-
-    return menu;
-}
-
-/* if caption of some button is NULL, the button is not included in menu (skipped) */
-static struct menu_panel *make_menu_panel(const struct button *origin,
-        struct font *font, size_t n_elems, struct menu_elem *elems)
-{
-    int maxlen = 0;
-
-    for (size_t i = 0; i < n_elems; i++) {
-        if (elems[i].caption == NULL) {
-            continue;
         }
-        int w;
-        get_string_metrics(font, elems[i].caption, &w, NULL);
-        maxlen = MAX(maxlen, w);
-    }
-
-    struct menu_panel *menu_panel = new_menu_panel();
-    if (menu_panel == NULL) {
-        return NULL;
-    }
-
-    SDL_Rect rect = {
-        origin->full_rect.x + origin->full_rect.w,
-        origin->full_rect.y,
-        DEFAULT_MENU_LINE_WIDTH(maxlen),
-        DEFAULT_MENU_LINE_HEIGHT(font->ttf.glyph.h)
-    };
-
-    menu_panel->rect = rect;
-    menu_panel->rect.h = 0;
-
-    for (size_t i = 0; i < n_elems; i++) {
-        if (elems[i].caption == NULL) {
-            continue;
-        }
-
-        struct button_callbacks callbacks = {
-            elems[i].on_render, NULL, elems[i].on_menu
-        };
-        push_button(&menu_panel->button_bank,
-                font,
-                elems[i].caption,
-                elems[i].disabled,
-                elems[i].data,
-                callbacks,
-                &rect,
-                CAPTION_POSITION_LEFT);
-
-        rect.y += rect.h;
-        menu_panel->rect.h += rect.h;
-    }
-
-    return menu_panel;
-}
-
-static void load_next_menu_panel(const struct window *window,
-        struct menu_panel *menu_panel, const struct button *origin,
-        size_t n_elems, struct menu_elem *elems)
-{
-    assert(menu_panel->next == NULL);
-    menu_panel->next = make_menu_panel(origin,
-            window->status_bar.font, n_elems, elems);
-}
-
-static void do_menu_cleanup(struct button *button,
-        struct menu_panel *menu_panel, const SDL_Event *event)
-{
-    switch (event->type) {
-        case SDL_MOUSEMOTION:     /* fallthru */
-        case SDL_MOUSEBUTTONDOWN: /* fallthru */
-        case SDL_MOUSEBUTTONUP:
-            if (menu_panel->next != NULL) {
-                free_menu_panel(menu_panel->next);
-                menu_panel->next = NULL;
-            }
-            break;
-        default:
-            quit_fmt("non mouse event %d for button '%s'",
-                    event->type, button->caption);
-            break;
-    }
-}
-
-static bool select_menu_button(struct button *button,
-        struct menu_panel *menu_panel, const SDL_Event *event)
-{
-    if (button->selected) {
-        return false;
+        signal_move_state(window);
     } else {
-        do_menu_cleanup(button, menu_panel, event);
-        button->selected = true;
-
-        return true;
+        if (window->move_state.active) {
+            /* toggle move button */
+            signal_move_state(window);
+        }
+        signal_size_state(window);
     }
 }
 
-static bool click_menu_button(struct button *button,
-        struct menu_panel *menu_panel, const SDL_Event *event)
+static void handle_menu_shortcuts(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    /* any event on that button removes the existing panel submenus
-     * (and clickable buttons should not have their own submenus) */
-    do_menu_cleanup(button, menu_panel, event);
+    int x = ctrl->rect.x, y = ctrl->rect.y;
 
-    switch (event->type) {
-        case SDL_MOUSEBUTTONDOWN:
-            button->selected = true;
-            return false;
-        case SDL_MOUSEBUTTONUP:
-            if (button->selected) {
-                button->selected = false;
-                /* click the button */
-                return true;
-            } else {
-                return false;
-            }
-        default:
-            return false;
-    }
+    sdlpui_popdown_dialog(dlg, window, true);
+    show_shortcut_editor(window, x, y);
 }
 
-static void handle_menu_sound_volume(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static void handle_menu_sound_volume(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_INT);
+    struct sdlpui_menu_button *mb;
+    int tag;
 
-    if (!click_menu_button(button, menu_panel, event)) {
-        return;
-    }
-
-    int increment =
-        (event->button.x - button->full_rect.x < button->full_rect.w / 2) ? -5 : +5;
-
-    if (button->data.value.int_value == BUTTON_VOLUME_SOUND) {
-        sound_volume += increment;
-        if (sound_volume < 0) {
-            sound_volume = 0;
-        } else if (sound_volume > 100) {
-            sound_volume = 100;
-        }
-    } else if (button->data.value.int_value == BUTTON_VOLUME_MUSIC) {
-        music_volume += increment;
-        if (music_volume < 0) {
-            music_volume = 0;
-        } else if (music_volume > 100) {
-            music_volume = 100;
-        }
+    SDL_assert(ctrl->type_code == SDLPUI_CTRL_MENU_BUTTON);
+    mb = (struct sdlpui_menu_button*)ctrl->priv;
+    SDL_assert(mb->subtype_code == SDLPUI_MB_RANGED_INT);
+    SDL_assert(ctrl->ftb->get_tag);
+    tag = (*ctrl->ftb->get_tag)(ctrl);
+    if (tag) {
+        sound_volume = mb->v.ranged_int.curr;
     } else {
-        quit_fmt("bad int_value in button '%s'", button->caption);
+        music_volume = mb->v.ranged_int.curr;
     }
 }
 
-static void handle_menu_sound(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static struct sdlpui_dialog *handle_menu_sound(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+        int ul_x_win, int ul_y_win)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_NONE);
+    struct sdlpui_dialog *result =
+        sdlpui_start_simple_menu(dlg, ctrl, 2, true, false, NULL, 0);
+    struct sdlpui_control *c;
 
-    if (!select_menu_button(button, menu_panel, event)) {
-        return;
-    }
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_menu_ranged_int(c, "- Sound Volume: %d +",
+        SDLPUI_HOR_LEFT, handle_menu_sound_volume, 0, false,
+        sound_volume, 0, 100);
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_menu_ranged_int(c, "- Music Volume: %d +",
+        SDLPUI_HOR_LEFT, handle_menu_sound_volume, 1, false,
+        music_volume, 0, 100);
+    sdlpui_complete_simple_menu(result, window);
+    result->rect.x = ul_x_win;
+    result->rect.y = ul_y_win;
 
-    struct menu_elem elems[] = {
-        {
-            "< Sound Volume: %d >",
-            {
-                BUTTON_DATA_INT,
-                {.int_value = BUTTON_VOLUME_SOUND},
-            },
-            render_button_menu_sound_volume,
-            handle_menu_sound_volume, false
-        },
-        {
-            "< Music Volume: %d >",
-            {
-                BUTTON_DATA_INT,
-                {.int_value = BUTTON_VOLUME_MUSIC},
-            },
-            render_button_menu_sound_volume,
-            handle_menu_sound_volume, false
-        }
-    };
-
-    load_next_menu_panel(window, menu_panel, button, N_ELEMENTS(elems), elems);
+    return result;
 }
 
-static void handle_menu_window(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static void handle_menu_window(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_UNSIGNED);
+    int tag;
+    struct sdlpui_window *other;
 
-    if (!click_menu_button(button, menu_panel, event)) {
-        return;
-    }
-
-    struct window *other = get_window_direct(button->data.value.unsigned_value);
+    SDL_assert(ctrl->ftb->get_tag);
+    tag = (*ctrl->ftb->get_tag)(ctrl);
+    SDL_assert(tag >= 0);
+    sdlpui_popdown_dialog(dlg, window, true);
+    other = get_window_direct(window->app, (unsigned int)tag);
     if (other == NULL) {
-        other = get_new_window(button->data.value.unsigned_value);
-        assert(other != NULL);
+        other = get_new_window(window->app, (unsigned int)tag);
+        SDL_assert(other != NULL);
         wipe_window_aux_config(other);
         start_window(other);
+    } else {
+        /* Previous versions didn't close.  Is that better? */
+        handle_window_closed(window->app, other);
     }
 }
 
-static void handle_menu_windows(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static struct sdlpui_dialog *handle_menu_windows(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+        int ul_x_win, int ul_y_win)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_NONE);
+    struct sdlpui_dialog *result = sdlpui_start_simple_menu(
+        dlg, ctrl, MAX_WINDOWS, true, false, NULL, 0);
+    unsigned int i;
 
-    if (!select_menu_button(button, menu_panel, event)) {
-        return;
+    for (i = 0; i < MAX_WINDOWS; ++i) {
+        struct sdlpui_control *c = sdlpui_get_simple_menu_next_unused(
+            result, SDLPUI_MFLG_NONE);
+
+        sdlpui_create_menu_toggle(c, format("Window-%u", i),
+            SDLPUI_HOR_LEFT, handle_menu_window, i, false,
+            get_window_direct(window->app, i) != NULL);
     }
+    sdlpui_complete_simple_menu(result, window);
+    result->rect.x = ul_x_win;
+    result->rect.y = ul_y_win;
 
-    struct menu_elem elems[MAX_WINDOWS];
-
-    for (unsigned i = 0; i < MAX_WINDOWS; i++) {
-        elems[i].caption = "Window-%u";
-        elems[i].data.type = BUTTON_DATA_UNSIGNED;
-        elems[i].data.value.unsigned_value = i;
-        elems[i].on_render = render_button_menu_window;
-        elems[i].on_menu = handle_menu_window;
-        elems[i].disabled = false;
-    }
-
-    load_next_menu_panel(window, menu_panel, button, N_ELEMENTS(elems), elems);
+    return result;
 }
 
-static void handle_menu_fullscreen(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static void handle_menu_fullscreen(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_NONE);
-
-    if (!click_menu_button(button, menu_panel, event)) {
-        return;
-    }
-
+    sdlpui_popdown_dialog(dlg, window, true);
     if (window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP) {
         SDL_SetWindowFullscreen(window->window, 0);
         SDL_SetWindowMinimumSize(window->window,
-                DEFAULT_WINDOW_MINIMUM_W, DEFAULT_WINDOW_MINIMUM_H);
+            DEFAULT_WINDOW_MINIMUM_W, DEFAULT_WINDOW_MINIMUM_H);
     } else {
-        SDL_SetWindowFullscreen(window->window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+        SDL_SetWindowFullscreen(window->window,
+            SDL_WINDOW_FULLSCREEN_DESKTOP);
     }
-
     window->flags = SDL_GetWindowFlags(window->window);
 }
 
-static void handle_menu_kp_mod(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static void handle_menu_kp_mod(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_NONE);
-
-    if (!click_menu_button(button, menu_panel, event)) {
-        return;
-    }
-
-    g_kp_as_mod = !g_kp_as_mod;
+    sdlpui_popdown_dialog(dlg, window, true);
+    window->app->kp_as_mod = !window->app->kp_as_mod;
 }
 
-static void handle_menu_about(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static void handle_menu_about(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_NONE);
+    int x = ctrl->rect.x, y = ctrl->rect.y;
 
-    if (!click_menu_button(button, menu_panel, event)) {
-        return;
-    }
-
-    show_about(window);
+    sdlpui_popdown_dialog(dlg, window, true);
+    show_about(window, x, y);
 }
 
-static void handle_menu_quit(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static void handle_menu_quit(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_NONE);
-
-    if (!click_menu_button(button, menu_panel, event)) {
-        return;
-    }
-
+    sdlpui_popdown_dialog(dlg, window, true);
     handle_quit();
 }
 
-static void handle_menu_tile_set(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static void handle_menu_tile_set(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_INT);
+    int new_id;
 
-    if (!click_menu_button(button, menu_panel, event)) {
-        return;
+    SDL_assert(ctrl->ftb->get_tag);
+    new_id = (*ctrl->ftb->get_tag)(ctrl);
+    if (new_id == current_graphics_mode->grafID) {
+        /*
+         * There's no change from the current graphics mode.
+         * Leave that button toggled on.
+         */
+        struct sdlpui_menu_button *mb;
+
+        SDL_assert(ctrl->type_code == SDLPUI_CTRL_MENU_BUTTON);
+        mb = (struct sdlpui_menu_button*)ctrl->priv;
+        SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
+        mb->v.toggled = true;
+        dlg->dirty = true;
+    } else {
+        /* Change the graphics mode.  Toggle off the old mode. */
+        int old_id = current_graphics_mode->grafID;
+        graphics_mode *mode = get_graphics_mode(new_id, true);
+        struct sdlpui_simple_menu *sm;
+        int i;
+
+        SDL_assert(mode);
+        SDL_assert(dlg->type_code == SDLPUI_DIALOG_SIMPLE_MENU);
+        sm = (struct sdlpui_simple_menu*)dlg->priv;
+        for (i = 0; i < sm->number; ++i) {
+            struct sdlpui_menu_button *mb;
+
+            SDL_assert(sm->controls[i].type_code
+                == SDLPUI_CTRL_MENU_BUTTON);
+            mb = (struct sdlpui_menu_button*)sm->controls[i].priv;
+            SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
+            if (mb->tag == old_id) {
+                mb->v.toggled = false;
+                dlg->dirty = true;
+                break;
+            }
+        }
+        reload_all_graphics(window->app, mode);
+        refresh_angband_terms(window->app);
     }
-    
-    graphics_mode *mode = get_graphics_mode(button->data.value.int_value, true);
-    assert(mode != NULL);
-
-    reload_all_graphics(mode);
-
-    refresh_angband_terms();
 }
 
-static void handle_menu_tile_size(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static void handle_menu_tile_size(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_INT);
+    struct subwindow *subwindow = Term->data;
+    assert(subwindow != NULL);
 
-    if (!click_menu_button(button, menu_panel, event)) {
-        return;
-    }
-    if (window->graphics.id == GRAPHICS_NONE) {
-        return;
-    }
+    struct sdlpui_menu_button *mb;
+    int tag;
 
-    int increment =
-        (event->button.x - button->full_rect.x < button->full_rect.w / 2) ? -1 : +1;
-
-    if (button->data.value.int_value == BUTTON_TILE_SIZE_WIDTH) {
-        tile_width += increment;
-        if (tile_width < MIN_TILE_WIDTH) {
-            tile_width = MAX_TILE_WIDTH;
-        } else if (tile_width > MAX_TILE_WIDTH) {
-            tile_width = MIN_TILE_WIDTH;
-        }
-    } else if (button->data.value.int_value == BUTTON_TILE_SIZE_HEIGHT) {
-        tile_height += increment;
-        if (tile_height < MIN_TILE_HEIGHT) {
-            tile_height = MAX_TILE_HEIGHT;
-        } else if (tile_height > MAX_TILE_HEIGHT) {
-            tile_height = MIN_TILE_HEIGHT;
-        }
+    SDL_assert(ctrl->type_code == SDLPUI_CTRL_MENU_BUTTON);
+    mb = (struct sdlpui_menu_button*)ctrl->priv;
+    SDL_assert(mb->subtype_code == SDLPUI_MB_RANGED_INT);
+    SDL_assert(ctrl->ftb->get_tag);
+    tag = (*ctrl->ftb->get_tag)(ctrl);
+    if (tag) {
+        tile_height = mb->v.ranged_int.curr;
     } else {
-        quit_fmt("bad int_value in button '%s'", button->caption);
+        tile_width = mb->v.ranged_int.curr;
     }
 
     /* Use ASCII symbol for distorted tiles */
     tile_distorted = is_tile_distorted(use_graphics, tile_width, tile_height);
 
-    refresh_angband_terms();
+    /* Dungeon size */
+    if (subwindow->index == MAIN_SUBWINDOW)
+        net_term_resize(subwindow->cols, subwindow->rows, subwindow->rows);
+
+    refresh_angband_terms(window->app);
 }
 
-static void handle_menu_tile_sizes(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static struct sdlpui_dialog *handle_menu_tile_sizes(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+        int ul_x_win, int ul_y_win)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_SUBWINDOW);
+    bool disabled = (window->graphics.id == GRAPHICS_NONE);
+    struct sdlpui_dialog *result =
+        sdlpui_start_simple_menu(dlg, ctrl, 2, true, false, NULL, 0);
+    struct sdlpui_control *c;
 
-    if (!select_menu_button(button, menu_panel, event)) {
-        return;
-    }
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_menu_ranged_int(c, "- Tile width  %d +",
+        SDLPUI_HOR_LEFT, handle_menu_tile_size, 0, disabled,
+        tile_width, MIN_TILE_WIDTH, MAX_TILE_WIDTH);
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_menu_ranged_int(c, "- Tile height %d +",
+        SDLPUI_HOR_LEFT, handle_menu_tile_size, 1, disabled,
+        tile_height, MIN_TILE_HEIGHT, MAX_TILE_HEIGHT);
+    sdlpui_complete_simple_menu(result, window);
+    result->rect.x = ul_x_win;
+    result->rect.y = ul_y_win;
 
-    /* Only allow changes to the graphics mode in initial phase */
-    struct menu_elem elems[] = {
-        {
-            "< Tile width  %d >",
-            {
-                BUTTON_DATA_INT,
-                {.int_value = BUTTON_TILE_SIZE_WIDTH},
-            },
-            render_button_menu_tile_size,
-            handle_menu_tile_size,
-            window->graphics.id == GRAPHICS_NONE || Setup.initialized
-        },
-        {
-            "< Tile height %d >",
-            {
-                BUTTON_DATA_INT,
-                {.int_value = BUTTON_TILE_SIZE_HEIGHT},
-            },
-            render_button_menu_tile_size,
-            handle_menu_tile_size,
-            window->graphics.id == GRAPHICS_NONE || Setup.initialized
-        }
-    };
-
-    load_next_menu_panel(window, menu_panel, button, N_ELEMENTS(elems), elems);
+    return result;
 }
 
-static void handle_menu_tile_sets(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static struct sdlpui_dialog *handle_menu_tile_sets(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+        int ul_x_win, int ul_y_win)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_SUBWINDOW);
-
-    if (!select_menu_button(button, menu_panel, event)) {
-        return;
-    }
-
-    size_t num_elems = 0;
     /* Only allow changes to the graphics mode in initial phase */
     bool disabled = Setup.initialized;
-    struct menu_elem *elems;
-
+    struct sdlpui_dialog *result = sdlpui_start_simple_menu(dlg, ctrl,
+        0, true, false, NULL, 0);
     graphics_mode *mode = graphics_modes;
-    while (mode != NULL) {
-        num_elems++;
+
+    while (mode) {
+        struct sdlpui_control *c = sdlpui_get_simple_menu_next_unused(
+            result, SDLPUI_MFLG_NONE);
+
+        sdlpui_create_menu_toggle(c, mode->menuname, SDLPUI_HOR_LEFT,
+            handle_menu_tile_set, mode->grafID, disabled,
+            current_graphics_mode->grafID == mode->grafID);
         mode = mode->pNext;
     }
+    sdlpui_complete_simple_menu(result, window);
+    result->rect.x = ul_x_win;
+    result->rect.y = ul_y_win;
 
-    elems = mem_alloc(num_elems * sizeof(*elems));
-
-    mode = graphics_modes;
-    for (size_t i = 0; i < num_elems; i++) {
-        elems[i].caption = mode->menuname;
-        elems[i].data.type = BUTTON_DATA_INT;
-        elems[i].data.value.int_value = mode->grafID;
-        elems[i].on_render = render_button_menu_tile_set;
-        elems[i].on_menu = handle_menu_tile_set;
-        elems[i].disabled = disabled;
-        mode = mode->pNext;
-    }
-
-    load_next_menu_panel(window, menu_panel, button, num_elems, elems);
-
-    mem_free(elems);
+    return result;
 }
 
-static void handle_menu_tiles(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static struct sdlpui_dialog *handle_menu_tiles(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+        int ul_x_win, int ul_y_win)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_SUBWINDOW);
+    struct sdlpui_dialog *result = sdlpui_start_simple_menu(dlg, ctrl, 2,
+        true, false, NULL, 0);
+    struct sdlpui_control *c;
 
-    if (!select_menu_button(button, menu_panel, event)) {
-        return;
-    }
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_submenu_button(c, "Set", SDLPUI_HOR_LEFT,
+        handle_menu_tile_sets, SDLPUI_CHILD_MENU_RIGHT, 0, false);
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_submenu_button(c, "Size", SDLPUI_HOR_LEFT,
+        handle_menu_tile_sizes, SDLPUI_CHILD_MENU_RIGHT, 0, false);
+    sdlpui_complete_simple_menu(result, window);
+    result->rect.x = ul_x_win;
+    result->rect.y = ul_y_win;
 
-    struct button_data data = {
-        BUTTON_DATA_SUBWINDOW, {.subwindow_value = button->data.value.subwindow_value}
-    };
-
-    struct menu_elem elems[] = {
-        {"Set", data, render_button_menu_simple, handle_menu_tile_sets, false},
-        {"Size", data, render_button_menu_simple, handle_menu_tile_sizes, false}
-    };
-
-    load_next_menu_panel(window, menu_panel, button, N_ELEMENTS(elems), elems);
+    return result;
 }
 
-static void handle_menu_pw(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static void handle_menu_pw(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_TERM_FLAG);
+    int tag, subw_idx, flag_idx;
+    struct sdlpui_menu_button *mb;
+    uint32_t *new_flags;
 
-    if (!click_menu_button(button, menu_panel, event)) {
-        return;
+    SDL_assert(ctrl->ftb->get_tag);
+    tag = (*ctrl->ftb->get_tag)(ctrl);
+    SDL_assert(tag >= 0);
+    subw_idx = tag / (int)N_ELEMENTS(window_flag_desc);
+    SDL_assert(subw_idx >= 0 && subw_idx != MAIN_SUBWINDOW
+        && subw_idx < (int)N_ELEMENTS(window_flag));
+    flag_idx = tag % (int)N_ELEMENTS(window_flag_desc);
+    SDL_assert(ctrl->type_code == SDLPUI_CTRL_MENU_BUTTON);
+    mb = (struct sdlpui_menu_button*)ctrl->priv;
+    SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
+    new_flags = mem_zalloc(N_ELEMENTS(window_flag) * sizeof(*new_flags));
+    if (mb->v.toggled) {
+        new_flags[subw_idx] |= (uint32_t)1 << flag_idx;
+    } else {
+        new_flags[subw_idx] &= ~((uint32_t)1 << flag_idx);
     }
-
-    uint32_t new_flags[N_ELEMENTS(window_flag)];
-    assert(sizeof(new_flags) == sizeof(window_flag));
-    memcpy(new_flags, window_flag, sizeof(new_flags));
-
-    struct subwindow *subwindow = button->data.value.term_flag_value.subwindow;
-
-    assert(subwindow->index != MAIN_SUBWINDOW);
-    assert(subwindow->index < N_ELEMENTS(window_flag));
-
-    uint32_t flag = button->data.value.term_flag_value.flag;
-
-    new_flags[subwindow->index] = flag;
-    subwindows_set_flags(new_flags, N_ELEMENTS(new_flags));
-
-    refresh_angband_terms();
+    subwindows_set_flags(new_flags, N_ELEMENTS(window_flag));
+    mem_free(new_flags);
+    refresh_angband_terms(window->app);
 }
 
-static void handle_menu_font_name(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static void handle_menu_font_name(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_FONT);
+    int tag, index, old_index;
+    struct subwindow *subwindow;
+    const struct font_info *font_info;
 
-    if (!click_menu_button(button, menu_panel, event)) {
+    SDL_assert(ctrl->ftb->get_tag);
+    tag = (*ctrl->ftb->get_tag)(ctrl);
+    subwindow = get_subwindow_by_index(window,
+        (unsigned int)(tag / (2 * window->app->font_count) - 1), false);
+    SDL_assert(subwindow);
+    index = (unsigned int)tag
+        % (unsigned int)(2 * window->app->font_count);
+    old_index = subwindow->font->index;
+    font_info = &window->app->fonts[index];
+
+    if (old_index == index) {
+        /*
+         * Already selected; pushing the button doesn't toggle it off.
+         */
+        struct sdlpui_menu_button *mb;
+
+        SDL_assert(ctrl->type_code == SDLPUI_CTRL_MENU_BUTTON);
+        mb = (struct sdlpui_menu_button*)ctrl->priv;
+        SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
+        mb->v.toggled = true;
+        dlg->dirty = true;
         return;
     }
-
-    assert(button->data.value.font_value.index < N_ELEMENTS(g_font_info));
-
-    unsigned index = button->data.value.font_value.index;
-    struct subwindow *subwindow = button->data.value.font_value.subwindow;
-
-    const struct font_info *font_info = &g_font_info[index];
-    assert(font_info->loaded);
-
-    if (subwindow->font->index == index) {
-        /* already loaded */
-        return;
-    } 
 
     if (reload_font(subwindow, font_info)) {
-        button->data.value.font_value.size_ok = true;
+        /* Set the previous selected font in the menu to off. */
+        int target_tag = tag
+            - (tag % (2 * window->app->font_count))
+            + old_index;
+        bool searching = true;
+
+        while (searching) {
+            struct sdlpui_simple_menu *sm;
+            struct sdlpui_control *pc;
+            int i;
+
+            SDL_assert(dlg->type_code == SDLPUI_DIALOG_SIMPLE_MENU);
+            sm = (struct sdlpui_simple_menu*)dlg->priv;
+            for (i = 0; i < sm->number; ++i) {
+                struct sdlpui_menu_button *mb;
+
+                SDL_assert(sm->controls[i].type_code
+                    == SDLPUI_CTRL_MENU_BUTTON);
+                mb = (struct sdlpui_menu_button*)sm->controls[i].priv;
+                if (mb->tag == target_tag) {
+                    mb->v.toggled = false;
+                    dlg->dirty = true;
+                    searching = false;
+                    break;
+                }
+            }
+
+            pc = sdlpui_get_dialog_parent_ctrl(dlg);
+            if (pc) {
+                struct sdlpui_menu_button *mbp;
+
+                SDL_assert(pc->type_code
+                    == SDLPUI_CTRL_MENU_BUTTON);
+                mbp = pc->priv;
+                if (streq(mbp->caption, "More")) {
+                    dlg = sdlpui_get_dialog_parent(dlg);
+                    SDL_assert(dlg);
+                } else {
+                    searching = false;
+                }
+            } else {
+                searching = false;
+            }
+        }
     } else {
-        button->data.value.font_value.size_ok = false;
+        /*
+         * Subwindow can't be resized to accommodate the font so
+         * disable it.
+         */
+        struct sdlpui_menu_button *mb;
+
+        SDL_assert(ctrl->type_code == SDLPUI_CTRL_MENU_BUTTON);
+        mb = (struct sdlpui_menu_button*)ctrl->priv;
+        SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
+        mb->disabled = true;
+        mb->v.toggled = false;
+        dlg->dirty = true;
     }
 }
 
-static void handle_menu_font_size(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static void handle_menu_font_size(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_FONT);
+    int tag;
+    struct subwindow *subwindow;
+    struct sdlpui_menu_button *mb;
+    struct font_info *info;
 
-    if (!click_menu_button(button, menu_panel, event)) {
-        return;
+    SDL_assert(ctrl->ftb->get_tag);
+    tag = (*ctrl->ftb->get_tag)(ctrl);
+    subwindow = get_subwindow_by_index(window, (unsigned int)tag, false);
+    SDL_assert(subwindow && subwindow->font);
+    info = &window->app->fonts[subwindow->font->index];
+    SDL_assert(ctrl->type_code == SDLPUI_CTRL_MENU_BUTTON);
+    mb = (struct sdlpui_menu_button*)ctrl->priv;
+    SDL_assert(mb->subtype_code == SDLPUI_MB_RANGED_INT);
+    info->size = mb->v.ranged_int.curr;
+    if (!reload_font(subwindow, info)) {
+        /*
+         * The range of sizes was limited in handle_menu_font_sizes(),
+         * so the call to reload_font() should have worked.
+         */
+        SDL_assert(0);
     }
-    if (!button->data.value.font_value.size_ok) {
-        return;
+}
+
+static struct sdlpui_dialog *handle_menu_font_sizes(
+        struct sdlpui_control *ctrl, struct sdlpui_dialog *dlg,
+        struct sdlpui_window *window, int ul_x_win, int ul_y_win)
+{
+    int tag;
+    struct subwindow *subwindow;
+    bool is_vector_font;
+    struct sdlpui_dialog *result;
+    struct sdlpui_control *c;
+
+    SDL_assert(ctrl->ftb->get_tag);
+    tag = (*ctrl->ftb->get_tag)(ctrl);
+    subwindow = get_subwindow_by_index(window, (unsigned int)tag, false);
+    SDL_assert(subwindow);
+    is_vector_font = window->app->fonts[subwindow->font->index].type
+        == FONT_TYPE_VECTOR;
+    calculate_subwindow_font_size_bounds(subwindow, NULL,
+        &subwindow->min_font_size, &subwindow->max_font_size);
+    SDL_assert(subwindow);
+    result = sdlpui_start_simple_menu(dlg, ctrl, 2, true, false, NULL, 0);
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_menu_ranged_int(c, "- %2d points +", SDLPUI_HOR_LEFT,
+        handle_menu_font_size, tag, !is_vector_font
+        || subwindow->min_font_size >= subwindow->max_font_size,
+        subwindow->font->size, subwindow->min_font_size,
+        (subwindow->min_font_size < subwindow->max_font_size) ?
+        subwindow->max_font_size - 1 : subwindow->min_font_size);
+    sdlpui_complete_simple_menu(result, window);
+    result->rect.x = ul_x_win;
+    result->rect.y = ul_y_win;
+
+    return result;
+}
+
+static struct sdlpui_dialog *handle_menu_font_names(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+        int ul_x_win, int ul_y_win)
+{
+    int tag;
+    SDL_Renderer *renderer;
+    struct subwindow *subwindow;
+    struct sdlpui_dialog *result;
+    struct sdlpui_control *c;
+    bool more_nesting = false;
+    int win_w, win_h, start, count, i;
+
+    renderer = sdlpui_get_renderer(window);
+    SDL_GetRendererOutputSize(renderer, &win_w, &win_h);
+    SDL_assert(ctrl->ftb->get_tag);
+    tag = (*ctrl->ftb->get_tag)(ctrl);
+    if (tag < 2 * window->app->font_count) {
+        /* At the top level */
+        subwindow = get_subwindow_by_index(window, tag, false);
+        tag = (tag + 1) * 2 * window->app->font_count;
+        start = 0;
+    } else {
+        /* Nested */
+        subwindow = get_subwindow_by_index(window,
+            tag / (2 * window->app->font_count) - 1, false);
+        start = tag % (2 * window->app->font_count)
+            - window->app->font_count;
+        assert(start >= 0);
+        tag -= start + window->app->font_count;
     }
-
-    unsigned index = button->data.value.font_value.index;
-    assert(index < N_ELEMENTS(g_font_info));
-
-    struct font_info *info = &g_font_info[index];
-
-    if (info->type == FONT_TYPE_RASTER) {
-        return;
+    SDL_assert(subwindow);
+    SDL_assert(start <= window->app->font_count);
+    /*
+     * Figure out how many entries can fit.  Use the size of the parent
+     * control as a proxy for the size of the individual menu elements.
+     */
+    SDL_assert(ctrl->rect.h > 0);
+    count = (win_h - ul_y_win) / ctrl->rect.h;
+    if (count < window->app->font_count - start
+            && count > 2
+            && win_w - ul_x_win >= (ctrl->rect.w + 1) / 2) {
+        --count;
+        more_nesting = true;
+    } else if (count > window->app->font_count - start) {
+        count = window->app->font_count - start;
     }
+    result = sdlpui_start_simple_menu(dlg, ctrl,
+        count + ((more_nesting) ? 1 : 0), true, false, NULL, 0);
+    if (more_nesting) {
+        c = sdlpui_get_simple_menu_next_unused(result,
+            SDLPUI_MFLG_NONE);
+        sdlpui_create_submenu_button(c, "More", SDLPUI_HOR_LEFT,
+            handle_menu_font_names, SDLPUI_CHILD_MENU_RIGHT,
+            tag + window->app->font_count + start + count, false);
+    }
+    for (i = start; i < start + count; ++i) {
+        c = sdlpui_get_simple_menu_next_unused(result,
+            SDLPUI_MFLG_NONE);
+        /*
+         * Optimistically assume that it'll be possible to resize
+         * the subwindow for this font.
+         */
+        sdlpui_create_menu_toggle(c, window->app->fonts[i].name,
+            SDLPUI_HOR_LEFT, handle_menu_font_name, tag + i,
+            false, subwindow->font->index == (unsigned int)i);
+    }
+    sdlpui_complete_simple_menu(result, window);
+    result->rect.x = ul_x_win;
+    result->rect.y = ul_y_win;
 
-    struct subwindow *subwindow = button->data.value.font_value.subwindow; 
+    return result;
+}
 
-    int size = subwindow->font->size;
+static struct sdlpui_dialog *handle_menu_purpose(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+        int ul_x_win, int ul_y_win)
+{
+    int i = 0, subw_idx;
+    struct sdlpui_dialog *result;
 
-    int increment =
-        (event->button.x - button->full_rect.x < button->full_rect.w / 2) ? -1 : +1;
+    SDL_assert(ctrl->ftb->get_tag);
+    subw_idx = (*ctrl->ftb->get_tag)(ctrl);
+    SDL_assert(subw_idx >= 0 && subw_idx != MAIN_SUBWINDOW);
+    result = sdlpui_start_simple_menu(dlg, ctrl,
+        (int)N_ELEMENTS(window_flag_desc), true, false, NULL, 0);
+    while (i < (int)N_ELEMENTS(window_flag_desc)) {
+        if (window_flag_desc[i]) {
+            struct sdlpui_control *c =
+                sdlpui_get_simple_menu_next_unused(result,
+                SDLPUI_MFLG_NONE);
 
-    for (size_t i = 0; i < MAX_VECTOR_FONT_SIZE - MIN_VECTOR_FONT_SIZE; i++) {
-        size += increment;
-        if (size > MAX_VECTOR_FONT_SIZE) {
-            size = MIN_VECTOR_FONT_SIZE;
-        } else if (size < MIN_VECTOR_FONT_SIZE) {
-            size = MAX_VECTOR_FONT_SIZE;
+            sdlpui_create_menu_toggle(c, window_flag_desc[i],
+                SDLPUI_HOR_LEFT, handle_menu_pw, subw_idx *
+                (int)N_ELEMENTS(window_flag_desc) + i, false,
+                window_flag[subw_idx] & ((uint32_t)1 << i));
         }
-        info->size = size;
-        if (reload_font(subwindow, info)) {
-            return;
-        }
+        ++i;
     }
+    sdlpui_complete_simple_menu(result, window);
+    result->rect.x = ul_x_win;
+    result->rect.y = ul_y_win;
 
-    button->data.value.font_value.size_ok = false;
+    return result;
 }
 
-static void handle_menu_font_sizes(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static struct sdlpui_dialog *handle_menu_font(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+        int ul_x_win, int ul_y_win)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_SUBWINDOW);
+    int tag;
+    struct sdlpui_dialog *result;
+    struct sdlpui_control *c;
 
-    if (!select_menu_button(button, menu_panel, event)) {
-        return;
-    }
+    SDL_assert(ctrl->ftb->get_tag);
+    tag = (*ctrl->ftb->get_tag)(ctrl);
+    result = sdlpui_start_simple_menu(dlg, ctrl, 2, true, false, NULL, 0);
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_submenu_button(c, "Name", SDLPUI_HOR_LEFT,
+        handle_menu_font_names, SDLPUI_CHILD_MENU_RIGHT, tag, false);
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_submenu_button(c, "Size", SDLPUI_HOR_LEFT,
+        handle_menu_font_sizes, SDLPUI_CHILD_MENU_RIGHT, tag, false);
+    sdlpui_complete_simple_menu(result, window);
+    result->rect.x = ul_x_win;
+    result->rect.y = ul_y_win;
 
-    struct subwindow *subwindow = button->data.value.subwindow_value;
-
-    struct button_data data = {
-        BUTTON_DATA_FONT,
-        {.font_value =
-            {.subwindow = subwindow, .index = subwindow->font->index, .size_ok = true}},
-    };
-    struct menu_elem elems[] = {
-        {"< %2d points >", data, render_button_menu_font_size, handle_menu_font_size, false}
-    };
-
-    load_next_menu_panel(window, menu_panel, button, N_ELEMENTS(elems), elems);
+    return result;
 }
 
-static void handle_menu_font_names(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static void handle_menu_borders(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_SUBWINDOW);
+    int tag;
+    struct subwindow *subwindow;
 
-    if (!select_menu_button(button, menu_panel, event)) {
-        return;
-    }
-
-    struct menu_elem elems[N_ELEMENTS(g_font_info)];
-
-    size_t num_elems = 0;
-    for (size_t i = 0; i < MAX_BUTTONS; i++) {
-        if (g_font_info[i].loaded) {
-            elems[num_elems].caption = g_font_info[i].name;
-            elems[num_elems].data.type = BUTTON_DATA_FONT;
-            elems[num_elems].data.value.font_value.subwindow = button->data.value.subwindow_value;
-            elems[num_elems].data.value.font_value.size_ok = true;
-            elems[num_elems].data.value.font_value.index = i;
-            elems[num_elems].on_render = render_button_menu_font_name;
-            elems[num_elems].on_menu = handle_menu_font_name;
-            elems[num_elems].disabled = false;
-            num_elems++;
-        }
-    }
-
-    load_next_menu_panel(window, menu_panel, button, num_elems, elems);
-}
-
-static void handle_menu_font_names_page(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_SUBWINDOW);
-
-    if (!select_menu_button(button, menu_panel, event)) {
-        return;
-    }
-
-    struct menu_elem elems[N_ELEMENTS(g_font_info)];
-
-    size_t num_elems = 0;
-    for (size_t i = MAX_BUTTONS; i < N_ELEMENTS(g_font_info); i++) {
-        if (g_font_info[i].loaded) {
-            elems[num_elems].caption = g_font_info[i].name;
-            elems[num_elems].data.type = BUTTON_DATA_FONT;
-            elems[num_elems].data.value.font_value.subwindow = button->data.value.subwindow_value;
-            elems[num_elems].data.value.font_value.size_ok = true;
-            elems[num_elems].data.value.font_value.index = i;
-            elems[num_elems].on_render = render_button_menu_font_name;
-            elems[num_elems].on_menu = handle_menu_font_name;
-            elems[num_elems].disabled = false;
-            num_elems++;
-        }
-    }
-
-    load_next_menu_panel(window, menu_panel, button, num_elems, elems);
-}
-
-static void handle_menu_purpose(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_SUBWINDOW);
-
-    struct subwindow *subwindow = button->data.value.subwindow_value;
-    assert(subwindow->index != MAIN_SUBWINDOW);
-
-    if (!select_menu_button(button, menu_panel, event)) {
-        return;
-    }
-
-    struct menu_elem elems[N_ELEMENTS(window_flag_desc)];
-
-    size_t num_elems = 0;
-    while (num_elems < N_ELEMENTS(elems)
-            && window_flag_desc[num_elems] != NULL)
-    {
-        elems[num_elems].caption = window_flag_desc[num_elems];
-        elems[num_elems].data.value.term_flag_value.subwindow = subwindow;
-        elems[num_elems].data.value.term_flag_value.flag =
-            ((uint32_t) 1) << num_elems;
-        elems[num_elems].data.type = BUTTON_DATA_TERM_FLAG;
-        elems[num_elems].on_render = render_button_menu_pw;
-        elems[num_elems].on_menu = handle_menu_pw;
-        elems[num_elems].disabled = false;
-        num_elems++;
-    }
-
-    load_next_menu_panel(window, menu_panel, button, num_elems, elems);
-}
-
-static void handle_menu_font(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_SUBWINDOW);
-
-    if (!select_menu_button(button, menu_panel, event)) {
-        return;
-    }
-
-    struct button_data data = {
-        BUTTON_DATA_SUBWINDOW, {.subwindow_value = button->data.value.subwindow_value}
-    };
-
-    if (!font_page)
-    {
-        struct menu_elem elems[] = {
-            {"Name", data, render_button_menu_simple, handle_menu_font_names, false},
-            {"Size", data, render_button_menu_simple, handle_menu_font_sizes, false}
-        };
-
-        load_next_menu_panel(window, menu_panel, button, N_ELEMENTS(elems), elems);
-    }
-    else
-    {
-        struct menu_elem elems[] = {
-            {"Name", data, render_button_menu_simple, handle_menu_font_names, false},
-            {" >>>", data, render_button_menu_simple, handle_menu_font_names_page, false},
-            {"Size", data, render_button_menu_simple, handle_menu_font_sizes, false}
-        };
-
-        load_next_menu_panel(window, menu_panel, button, N_ELEMENTS(elems), elems);
-    }
-}
-
-static void handle_menu_borders(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_SUBWINDOW);
-
-    if (!click_menu_button(button, menu_panel, event)) {
-        return;
-    }
-
-    struct subwindow *subwindow = button->data.value.subwindow_value;
-
+    SDL_assert(ctrl->ftb->get_tag);
+    tag = (*ctrl->ftb->get_tag)(ctrl);
+    SDL_assert(tag >= 0);
+    subwindow = get_subwindow_by_index(window, (unsigned int)tag, false);
+    SDL_assert(subwindow);
     subwindow->borders.visible = !subwindow->borders.visible;
     render_borders(subwindow);
 }
 
-static void handle_menu_subwindow_alpha(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static void handle_menu_subwindow_alpha(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_ALPHA);
+    int tag;
+    struct subwindow *subwindow;
+    struct sdlpui_simple_menu *sm;
+    int new_alpha, i;
 
-    if (!click_menu_button(button, menu_panel, event)) {
+    SDL_assert(ctrl->ftb->get_tag);
+    tag = (*ctrl->ftb->get_tag)(ctrl);
+    SDL_assert(tag >= 0);
+    subwindow = get_subwindow_by_index(window, (unsigned int)tag / 101,
+        false);
+    SDL_assert(subwindow);
+    new_alpha = ALPHA_PERCENT((tag % 101));
+    if (is_close_to(new_alpha, subwindow->color.a,
+            DEFAULT_ALPHA_STEP / 2)) {
+        /*
+         * Already selected; pushing the button doesn't toggle it off.
+         */
+        struct sdlpui_menu_button *mb;
+
+        SDL_assert(ctrl->type_code == SDLPUI_CTRL_MENU_BUTTON);
+        mb = (struct sdlpui_menu_button*)ctrl->priv;
+        SDL_assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
+        mb->v.toggled = true;
+        dlg->dirty = true;
         return;
     }
+    /* Toggle off the previous setting. */
+    SDL_assert(dlg->type_code == SDLPUI_DIALOG_SIMPLE_MENU);
+    sm = (struct sdlpui_simple_menu*)dlg->priv;
+    for (i = 0; i < sm->number; ++i) {
+        struct sdlpui_menu_button *mb;
+        int alpha;
 
-    struct subwindow *subwindow = button->data.value.alpha_value.subwindow;
-    subwindow->color.a = button->data.value.alpha_value.real_value;
-
+        SDL_assert(sm->controls[i].type_code
+            == SDLPUI_CTRL_MENU_BUTTON);
+        mb = (struct sdlpui_menu_button*)sm->controls[i].priv;
+        alpha = ALPHA_PERCENT((mb->tag % 101));
+        if (is_close_to(alpha, subwindow->color.a,
+                DEFAULT_ALPHA_STEP / 2)) {
+            mb->v.toggled = false;
+            dlg->dirty = true;
+            break;
+        }
+    }
+    /* Change to the new setting. */
+    subwindow->color.a = new_alpha;
     render_clear(subwindow->window, subwindow->texture, &subwindow->color);
     render_borders(subwindow);
-
-    refresh_angband_terms();
+    refresh_angband_terms(subwindow->app);
 }
 
-static void handle_menu_alpha(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static struct sdlpui_dialog *handle_menu_alpha(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+        int ul_x_win, int ul_y_win)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_SUBWINDOW);
+    int tag, nstep, i;
+    struct subwindow *subwindow;
+    struct sdlpui_dialog *result;
 
-    if (!select_menu_button(button, menu_panel, event)) {
-        return;
+    SDL_assert(ctrl->ftb->get_tag);
+    tag = (*ctrl->ftb->get_tag)(ctrl);
+    SDL_assert(tag >= 0);
+    subwindow = get_subwindow_by_index(window, (unsigned int)tag, false);
+    SDL_assert(subwindow);
+    nstep = 1 + ((100 - DEFAULT_ALPHA_LOWEST + (DEFAULT_ALPHA_STEP - 1))
+        / DEFAULT_ALPHA_STEP);
+    result = sdlpui_start_simple_menu(dlg, ctrl, nstep, true, false,
+        NULL, 0);
+    for (i = 0; i < nstep; ++i) {
+        int alpha_pct = MIN(100,
+            DEFAULT_ALPHA_LOWEST + i * DEFAULT_ALPHA_STEP);
+        int alpha = ALPHA_PERCENT(alpha_pct);
+        struct sdlpui_control *c = sdlpui_get_simple_menu_next_unused(
+            result, SDLPUI_MFLG_NONE);
+
+        sdlpui_create_menu_toggle(c, format(" %3d%% ", alpha_pct),
+            SDLPUI_HOR_LEFT, handle_menu_subwindow_alpha,
+            101 * tag + alpha_pct, false,
+            is_close_to(alpha, subwindow->color.a,
+            DEFAULT_ALPHA_STEP / 2));
     }
+    sdlpui_complete_simple_menu(result, window);
+    result->rect.x = ul_x_win;
+    result->rect.y = ul_y_win;
 
-    struct subwindow *subwindow = button->data.value.subwindow_value;
-
-    struct menu_elem elems[(100 - DEFAULT_ALPHA_LOWEST) / DEFAULT_ALPHA_STEP +
-        1 + ((100 - DEFAULT_ALPHA_LOWEST) % DEFAULT_ALPHA_STEP == 0 ? 0 : 1)];
-
-    for (size_t i = 0; i < N_ELEMENTS(elems); i++) {
-        int alpha = ALPHA_PERCENT(DEFAULT_ALPHA_LOWEST + i * DEFAULT_ALPHA_STEP);
-
-        elems[i].caption = " %3d%% ";
-        elems[i].data.type = BUTTON_DATA_ALPHA;
-        elems[i].data.value.alpha_value.subwindow = subwindow;
-        elems[i].data.value.alpha_value.real_value = alpha;
-        elems[i].data.value.alpha_value.show_value = i * DEFAULT_ALPHA_STEP;
-        elems[i].on_render = render_button_menu_alpha;
-        elems[i].on_menu = handle_menu_subwindow_alpha;
-        elems[i].disabled = false;
-    }
-    elems[N_ELEMENTS(elems) - 1].data.value.alpha_value.real_value =
-        DEFAULT_ALPHA_FULL;
-
-    load_next_menu_panel(window, menu_panel, button, N_ELEMENTS(elems), elems);
+    return result;
 }
 
-static void handle_menu_top(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static void handle_menu_top(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_SUBWINDOW);
-    
-    if (!click_menu_button(button, menu_panel, event)) {
-        return;
-    }
+    int tag;
+    struct subwindow *subwindow;
 
-    struct subwindow *subwindow = button->data.value.subwindow_value;
-
+    SDL_assert(ctrl->ftb->get_tag);
+    tag = (*ctrl->ftb->get_tag)(ctrl);
+    SDL_assert(tag >= 0);
+    subwindow = get_subwindow_by_index(window, (unsigned int)tag, false);
+    SDL_assert(subwindow);
     subwindow->always_top = !subwindow->always_top;
-
     sort_to_top(subwindow->window);
 }
 
-static void handle_menu_terms(struct window *window,
-        struct button *button, const SDL_Event *event,
-        struct menu_panel *menu_panel)
+static void handle_menu_term_pop(struct sdlpui_dialog *dlg,
+        struct sdlpui_window *window, bool up)
 {
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_SUBWINDOW);
+    struct subwindow *subwindow = get_subwindow_by_index(window,
+        (unsigned int)dlg->tag, false);
 
-    if (!select_menu_button(button, menu_panel, event)) {
-        return;
-    }
-
-    struct subwindow *subwindow = button->data.value.subwindow_value;
-
-    struct button_data data = {
-        BUTTON_DATA_SUBWINDOW, {.subwindow_value = subwindow}
-    };
-
-    struct menu_elem elems[] = {
-        {
-            "Font", data, render_button_menu_simple, handle_menu_font, false
-        },
-        {
-            subwindow->index == MAIN_SUBWINDOW ? "Tiles" : NULL,
-            data, render_button_menu_simple, handle_menu_tiles, false
-        },
-        {
-            subwindow->index == MAIN_SUBWINDOW ? NULL: "Purpose",
-            data, render_button_menu_simple, handle_menu_purpose, false
-        },
-        {
-            "Alpha", data, render_button_menu_simple, handle_menu_alpha, false
-        },
-        {
-            "Borders", data, render_button_menu_borders, handle_menu_borders, false
-        },
-        {
-            "Top", data, render_button_menu_top, handle_menu_top, false
-        }
-    };
-
-    load_next_menu_panel(window, menu_panel, button, N_ELEMENTS(elems), elems);
+    /*
+     * When the menu is visible, signal that the subwindow should have a
+     * pronounced border so it is easy to see where the changes will be
+     * made.
+     */
+    window->outlined_subwindow = (up) ? subwindow->index : (unsigned)-1;
 }
 
-static void load_main_menu_panel(struct status_bar *status_bar)
+static struct sdlpui_dialog *handle_menu_terms(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window,
+        int ul_x_win, int ul_y_win)
 {
-    assert(N_ELEMENTS(angband_term_name) == MAX_SUBWINDOWS);
+    int tag;
+    struct subwindow *subwindow;
+    struct sdlpui_dialog *result;
+    struct sdlpui_control *c;
 
-    struct menu_elem term_elems[N_ELEMENTS(angband_term_name)];
-    size_t n_terms = 0;
+    SDL_assert(ctrl->ftb->get_tag);
+    tag = (*ctrl->ftb->get_tag)(ctrl);
+    SDL_assert(tag >= 0);
+    subwindow = get_subwindow_by_index(window, (unsigned int)tag, false);
+    SDL_assert(subwindow);
+    result = sdlpui_start_simple_menu(dlg, ctrl,
+        (subwindow->index == MAIN_SUBWINDOW) ? 4 : 5, true, false,
+        handle_menu_term_pop, tag);
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_submenu_button(c, "Font", SDLPUI_HOR_LEFT,
+        handle_menu_font, SDLPUI_CHILD_MENU_RIGHT, tag, false);
+    if (subwindow->index == MAIN_SUBWINDOW) {
+        c = sdlpui_get_simple_menu_next_unused(result,
+            SDLPUI_MFLG_NONE);
+        sdlpui_create_submenu_button(c, "Tiles", SDLPUI_HOR_LEFT,
+            handle_menu_tiles, SDLPUI_CHILD_MENU_RIGHT, 0, false);
+    } else {
+        c = sdlpui_get_simple_menu_next_unused(result,
+            SDLPUI_MFLG_NONE);
+        sdlpui_create_submenu_button(c, "Purpose", SDLPUI_HOR_LEFT,
+            handle_menu_purpose, SDLPUI_CHILD_MENU_RIGHT, tag,
+            false);
+    }
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_submenu_button(c, "Alpha", SDLPUI_HOR_LEFT,
+        handle_menu_alpha, SDLPUI_CHILD_MENU_RIGHT, tag, false);
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_menu_toggle(c, "Borders", SDLPUI_HOR_LEFT,
+        handle_menu_borders, tag, false, subwindow->borders.visible);
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_menu_toggle(c, "Top", SDLPUI_HOR_LEFT,
+        handle_menu_top, tag, false, subwindow->always_top);
+    sdlpui_complete_simple_menu(result, window);
+    result->rect.x = ul_x_win;
+    result->rect.y = ul_y_win;
 
-    for (size_t i = 0; i < N_ELEMENTS(angband_term_name); i++) {
+    return result;
+}
+
+static struct sdlpui_dialog *handle_menu_button(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *parent, struct sdlpui_window *window,
+        int ul_x_win, int ul_y_win)
+{
+    struct sdlpui_dialog *result = sdlpui_start_simple_menu(
+        parent, ctrl, 3 + (int)N_ELEMENTS(angband_term_name)
+        + ((window->index == MAIN_WINDOW) ? 2 : 0), true, false,
+        NULL, 0);
+    unsigned int i;
+    struct sdlpui_control *c;
+
+    for (i = 0; i < (unsigned int)N_ELEMENTS(angband_term_name); ++i) {
         struct subwindow *subwindow =
-            get_subwindow_by_index(status_bar->window, i, true);
-        if (subwindow == NULL) {
+            get_subwindow_by_index(window, i, true);
+
+        if (!subwindow) {
             continue;
         }
-
-        term_elems[n_terms].caption = angband_term_name[i];
-        term_elems[n_terms].data.type = BUTTON_DATA_SUBWINDOW;
-        term_elems[n_terms].data.value.subwindow_value = subwindow;
-        term_elems[n_terms].on_render = render_button_menu_terms;
-        term_elems[n_terms].on_menu = handle_menu_terms;
-        term_elems[n_terms].disabled = false;
-        n_terms++;
+        c = sdlpui_get_simple_menu_next_unused(result,
+            SDLPUI_MFLG_NONE);
+        sdlpui_create_submenu_button(c, angband_term_name[i],
+            SDLPUI_HOR_LEFT, handle_menu_terms,
+            SDLPUI_CHILD_MENU_RIGHT, (int)i, false);
     }
-
-    struct button_data data = {BUTTON_DATA_NONE, {0}};
-    struct menu_elem other_elems[] = {
-        {
-            "Fullscreen",
-            data, render_button_menu_fullscreen, handle_menu_fullscreen, false
-        },
-        {
-            status_bar->window->index == MAIN_WINDOW ? "Send Keypad Modifier" : NULL,
-            data, render_button_menu_kp_mod, handle_menu_kp_mod, false
-        },
-        {
-            status_bar->window->index == MAIN_WINDOW ? "Sound" : NULL,
-            data, render_button_menu_simple, handle_menu_sound, false
-        },
-        {
-            status_bar->window->index == MAIN_WINDOW ? "Windows" : NULL,
-            data, render_button_menu_simple, handle_menu_windows, false
-        },
-        {
-            "About",
-            data, render_button_menu_simple, handle_menu_about, false
-        },
-        {
-            "Quit", 
-            data, render_button_menu_simple, handle_menu_quit, false
-        }
-    };
-
-    struct menu_elem elems[N_ELEMENTS(term_elems) + N_ELEMENTS(other_elems)];
-
-    memcpy(elems, term_elems, n_terms * sizeof(term_elems[0]));
-    memcpy(elems + n_terms, other_elems, sizeof(other_elems));
-
-    struct button dummy = {0};
-    dummy.full_rect.x = status_bar->full_rect.x;
-    dummy.full_rect.y = status_bar->full_rect.y + status_bar->full_rect.h;
-
-    status_bar->menu_panel = make_menu_panel(&dummy, status_bar->font,
-            n_terms + N_ELEMENTS(other_elems), elems);
-}
-
-static void unselect_menu_buttons(struct menu_panel *menu_panel)
-{
-    if (menu_panel == NULL) {
-        return;
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_menu_toggle(c, "Fullscreen", SDLPUI_HOR_LEFT,
+        handle_menu_fullscreen, 0, false,
+        window->flags & SDL_WINDOW_FULLSCREEN_DESKTOP);
+    if (window->index == MAIN_WINDOW) {
+        c = sdlpui_get_simple_menu_next_unused(result,
+            SDLPUI_MFLG_NONE);
+        sdlpui_create_menu_toggle(c, "Send Keypad Modifier",
+            SDLPUI_HOR_LEFT, handle_menu_kp_mod, 0, false,
+            window->app->kp_as_mod);
+        c = sdlpui_get_simple_menu_next_unused(result,
+            SDLPUI_MFLG_NONE);
+        sdlpui_create_menu_button(c, "Menu Shortcuts...",
+            SDLPUI_HOR_LEFT, handle_menu_shortcuts, 0, false);
+        c = sdlpui_get_simple_menu_next_unused(result,
+            SDLPUI_MFLG_NONE);
+        sdlpui_create_submenu_button(c, "Sound", SDLPUI_HOR_LEFT,
+            handle_menu_sound, SDLPUI_CHILD_MENU_RIGHT, 0, false);
+        c = sdlpui_get_simple_menu_next_unused(result,
+            SDLPUI_MFLG_NONE);
+        sdlpui_create_submenu_button(c, "Windows", SDLPUI_HOR_LEFT,
+            handle_menu_windows, SDLPUI_CHILD_MENU_RIGHT, 0, false);
     }
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_menu_button(c, "About...", SDLPUI_HOR_LEFT,
+        handle_menu_about, 0, false);
+    c = sdlpui_get_simple_menu_next_unused(result, SDLPUI_MFLG_NONE);
+    sdlpui_create_menu_button(c, "Quit", SDLPUI_HOR_LEFT,
+        handle_menu_quit, 0, false);
+    sdlpui_complete_simple_menu(result, window);
+    result->rect.x = ul_x_win;
+    result->rect.y = ul_y_win;
 
-    for (size_t i = 0; i < menu_panel->button_bank.number; i++) {
-        menu_panel->button_bank.buttons[i].selected = false;
-        menu_panel->button_bank.buttons[i].highlighted = false;
-    }
-
-    unselect_menu_buttons(menu_panel->next);
-}
-
-static bool handle_menu_event(struct window *window, const SDL_Event *event)
-{
-    int x = -1;
-    int y = -1;
-
-    switch (event->type) {
-        case SDL_MOUSEMOTION:
-            x = event->motion.x;
-            y = event->motion.y;
-            break;
-
-        case SDL_MOUSEBUTTONUP: /* fallthru */
-        case SDL_MOUSEBUTTONDOWN:
-            x = event->button.x;
-            y = event->button.y;
-            break;
-
-        default:
-            return false;
-    }
-
-    assert(x >= 0);
-    assert(y >= 0);
-
-    struct menu_panel *menu_panel =
-        get_menu_panel_by_xy(window->status_bar.menu_panel, x, y);
-
-    if (menu_panel == NULL) {
-        return false;
-    }
-
-    bool handled = false;
-
-    for (size_t i = 0; i < menu_panel->button_bank.number; i++) {
-        struct button *button = &menu_panel->button_bank.buttons[i];
-        if (is_point_in_rect(x, y, &button->full_rect)) {
-            /* note that the buttons themselves set "selected" */
-            button->highlighted = true;
-
-            assert(button->callbacks.on_menu != NULL);
-            if (!button->disabled) {
-                button->callbacks.on_menu(window, button,
-                    event, menu_panel);
-                handled = true;
-            }
-        } else {
-            button->highlighted = false;
-            /* but we do unset selected */
-            button->selected = false;
-        }
-    }
-
-    unselect_menu_buttons(menu_panel->next);
-
-    return handled;
-}
-
-static bool is_menu_button_mouse_click(const struct button *button,
-        const SDL_Event *event)
-{
-    if ((event->type == SDL_MOUSEBUTTONDOWN || event->type == SDL_MOUSEBUTTONUP)
-            && is_point_in_rect(event->button.x, event->button.y, &button->full_rect))
-    {
-        return true;
-    }
-
-    return false;
-}
-
-static bool handle_menu_button(struct window *window,
-        struct button *button, const SDL_Event *event)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_NONE);
-
-    switch (event->type) {
-        case SDL_MOUSEMOTION:
-            if (is_point_in_rect(event->motion.x, event->motion.y, &button->full_rect)) {
-                /* create menu on mouseover */
-                if (window->status_bar.menu_panel == NULL) {
-                    load_main_menu_panel(&window->status_bar);
-                }
-                button->highlighted = true;
-                return true;
-            } else if (handle_menu_event(window, event)) {
-                return true;
-            } else if (button->highlighted) {
-                /* the menu sticks around so that it is not horrible to use */
-                return true;
-            }
-            return false;
-        default:
-            if (handle_menu_event(window, event)) {
-                return true;
-            } else if (is_menu_button_mouse_click(button, event)) {
-                /* menu button just eats mouse clicks */
-                return true;
-            }
-
-            if (window->status_bar.menu_panel != NULL) {
-                free_menu_panel(window->status_bar.menu_panel);
-                window->status_bar.menu_panel = NULL;
-            }
-            button->highlighted = false;
-            return false;
-    }
+    return result;
 }
 
 static bool is_close_to(int a, int b, unsigned range)
@@ -2988,7 +3013,7 @@ static void crop_rects(SDL_Rect *src, SDL_Rect *dst)
 
 /* tries to snap to other term in such a way so that their
  * (visible) borders overlap */
-static void try_snap(struct window *window,
+static void try_snap(struct sdlpui_window *window,
         struct subwindow *subwindow, SDL_Rect *rect)
 {
     for (size_t i = N_ELEMENTS(window->subwindows); i > 0; i--) {
@@ -3024,7 +3049,7 @@ static void try_snap(struct window *window,
     }
 }
 
-static void start_moving(struct window *window,
+static void start_moving(struct sdlpui_window *window,
         struct subwindow *subwindow, const SDL_MouseButtonEvent *mouse)
 {
     assert(!window->size_state.active);
@@ -3038,7 +3063,7 @@ static void start_moving(struct window *window,
     window->move_state.moving = true;
 }
 
-static void start_sizing(struct window *window,
+static void start_sizing(struct sdlpui_window *window,
         struct subwindow *subwindow, const SDL_MouseButtonEvent *mouse)
 {
     assert(!window->move_state.active);
@@ -3060,31 +3085,8 @@ static void start_sizing(struct window *window,
     window->size_state.sizing = true;
 }
 
-static bool handle_menu_mousebuttondown(struct window *window,
-        const SDL_MouseButtonEvent *mouse)
+static void handle_window_closed(struct my_app *a, struct sdlpui_window *window)
 {
-    if (window->move_state.active || window->size_state.active) {
-        struct subwindow *subwindow = get_subwindow_by_xy(window, mouse->x, mouse->y);
-        if (subwindow != NULL
-                && is_rect_in_rect(&subwindow->full_rect, &window->inner_rect))
-        {
-            if (window->move_state.active && !window->move_state.moving) {
-                start_moving(window, subwindow, mouse);
-            } else if (window->size_state.active && !window->size_state.sizing) {
-                start_sizing(window, subwindow, mouse);
-            }
-        }
-        return true;
-    } else if (is_over_status_bar(&window->status_bar, mouse->x, mouse->y)) {
-        return true;
-    } else {
-        return false;
-    }
-}
-
-static void handle_window_closed(const SDL_WindowEvent *event)
-{
-    struct window *window = get_window_by_id(event->windowID);
     assert(window != NULL);
 
     if (window->index == MAIN_WINDOW) {
@@ -3097,32 +3099,79 @@ static void handle_window_closed(const SDL_WindowEvent *event)
             }
         }
         free_window(window);
+        if (a->w_mouse == window) {
+            a->w_mouse = NULL;
+        }
+        if (a->w_key == window) {
+            a->w_key = NULL;
+        }
     }
 }
 
-static void handle_window_focus(const SDL_WindowEvent *event)
+static void handle_window_focus(struct my_app *a, const SDL_WindowEvent *event)
 {
-    assert(event->event == SDL_WINDOWEVENT_FOCUS_GAINED
-            || event->event == SDL_WINDOWEVENT_FOCUS_LOST);
+    struct sdlpui_window *new_w;
 
-    struct window *window = get_window_by_id(event->windowID);
-    if (window == NULL) {
-        /* when window is closed, it sends FOCUS_LOST event */
-        assert(event->event == SDL_WINDOWEVENT_FOCUS_LOST);
-        return;
-    }
-    
     switch (event->event) {
+        case SDL_WINDOWEVENT_ENTER:
+            new_w = get_window_by_id(a, event->windowID);
+            SDLPUI_EVENT_TRACER("window", new_w,
+                "(not extracted)", "mouse entered");
+            if (a->w_mouse && a->w_mouse != new_w
+                    && a->w_mouse->d_mouse) {
+                if (a->w_mouse->d_mouse->ftb->handle_window_loses_mouse) {
+                    (*a->w_mouse->d_mouse->ftb->handle_window_loses_mouse)(
+                        a->w_mouse->d_mouse, a->w_mouse);
+                }
+                a->w_mouse->d_mouse = NULL;
+            }
+            a->w_mouse = new_w;
+            break;
+        case SDL_WINDOWEVENT_LEAVE:
+            SDLPUI_EVENT_TRACER("window", a->w_mouse,
+                "(not extracted)", "mouse left");
+            if (a->w_mouse && a->w_mouse->d_mouse) {
+                if (a->w_mouse->d_mouse->ftb->handle_window_loses_mouse) {
+                    (*a->w_mouse->d_mouse->ftb->handle_window_loses_mouse)(
+                        a->w_mouse->d_mouse, a->w_mouse);
+                }
+                a->w_mouse->d_mouse = NULL;
+            }
+            a->w_mouse = NULL;
+            break;
         case SDL_WINDOWEVENT_FOCUS_GAINED:
-            window->focus = true;
+            new_w = get_window_by_id(a, event->windowID);
+            SDLPUI_EVENT_TRACER("window", new_w,
+                "(not extracted)", "gained key focus");
+            if (a->w_key && a->w_key != new_w
+                    && a->w_key->d_key) {
+                if (a->w_key->d_key->ftb->handle_window_loses_key) {
+                    (*a->w_key->d_key->ftb->handle_window_loses_key)(
+                        a->w_key->d_key, a->w_key);
+                }
+                a->w_key->d_key = NULL;
+            }
+            a->w_key = new_w;
             break;
         case SDL_WINDOWEVENT_FOCUS_LOST:
-            window->focus = false;
+            SDLPUI_EVENT_TRACER("window", a->w_key,
+                "(not extracted)", "lost key focus");
+            if (a->w_key && a->w_key->d_key) {
+                if (a->w_key->d_key->ftb->handle_window_loses_key) {
+                    (*a->w_key->d_key->ftb->handle_window_loses_key)(
+                        a->w_key->d_key, a->w_key);
+                }
+                a->w_key->d_key = NULL;
+            }
+            a->w_key = NULL;
             break;
+        default:
+            assert(0);
     }
 }
 
-static void handle_last_resize_event(int num_events, const SDL_Event *events)
+static void handle_last_resize_event(struct my_app *a, int num_events,
+        const SDL_Event *events)
 {
     assert(num_events > 0);
 
@@ -3130,7 +3179,8 @@ static void handle_last_resize_event(int num_events, const SDL_Event *events)
         if (events[i].window.event == SDL_WINDOWEVENT_RESIZED) {
             const SDL_WindowEvent event = events[i].window;
 
-            struct window *window = get_window_by_id(event.windowID);
+            struct sdlpui_window *window =
+                get_window_by_id(a, event.windowID);
             assert(window != NULL);
             resize_window(window, event.data1, event.data2);
 
@@ -3139,7 +3189,7 @@ static void handle_last_resize_event(int num_events, const SDL_Event *events)
     }
 }
 
-static void handle_windowevent(const SDL_WindowEvent *event)
+static void handle_windowevent(struct my_app *a, const SDL_WindowEvent *event)
 {
     SDL_Event events[128];
     events[0].window = *event;
@@ -3150,26 +3200,39 @@ static void handle_windowevent(const SDL_WindowEvent *event)
     bool resize = false;
 
     for (int i = 0; i < num_events; i++) {
+        struct sdlpui_window *window;
+
+        window = get_window_by_id(a, events[i].window.windowID);
+        if (!window) {
+            continue;
+        }
+        if (window->move_state.active) {
+            signal_move_state(window);
+        } else if (window->size_state.active) {
+            signal_size_state(window);
+        }
         switch (events[i].window.event) {
             case SDL_WINDOWEVENT_RESIZED:
                 /* just for efficiency */
                 resize = true;
                 break;
             case SDL_WINDOWEVENT_CLOSE:
-                handle_window_closed(&events[i].window);
+                handle_window_closed(a, window);
                 break;
-            case SDL_WINDOWEVENT_FOCUS_GAINED: /* fallthru */
+            case SDL_WINDOWEVENT_ENTER: /* fallthrough */
+            case SDL_WINDOWEVENT_LEAVE:
+            case SDL_WINDOWEVENT_FOCUS_GAINED:
             case SDL_WINDOWEVENT_FOCUS_LOST:
-                handle_window_focus(&events[i].window);
+                handle_window_focus(a, &events[i].window);
                 break;
         }
     }
 
     if (resize) {
-        handle_last_resize_event(num_events, events);
+        handle_last_resize_event(a, num_events, events);
     }
 
-    redraw_all_windows(false);
+    redraw_all_windows(a, false);
 }
 
 static void resize_subwindow(struct subwindow *subwindow)
@@ -3199,24 +3262,22 @@ static void resize_subwindow(struct subwindow *subwindow)
     if (subwindow->index == MAIN_SUBWINDOW)
         net_term_resize(subwindow->cols, subwindow->rows, subwindow->rows);
 
-    refresh_angband_terms();
+    refresh_angband_terms(subwindow->app);
 }
 
-static void do_sizing(struct window *window, int x, int y)
+static void do_sizing(struct sdlpui_window *window, int x, int y)
 {
     struct size_state *size_state = &window->size_state;
-
-    assert(size_state->subwindow != NULL);
-
-    SDL_Rect rect = size_state->subwindow->sizing_rect;
-
     int newx = x - size_state->originx;
     int newy = y - size_state->originy;
-
-    int left   = size_state->left ? newx : 0;
-    int top    = size_state->top  ? newy : 0;
-    int right  = size_state->left ? 0 : newx;
+    int left = size_state->left ? newx : 0;
+    int top = size_state->top  ? newy : 0;
+    int right = size_state->left ? 0 : newx;
     int bottom = size_state->top  ? 0 : newy;
+    SDL_Rect rect;
+
+    assert(size_state->subwindow != NULL);
+    rect = size_state->subwindow->sizing_rect;
 
     resize_rect(&rect, left, top, right, bottom);
     fit_rect_in_rect_by_hw(&rect, &window->inner_rect);
@@ -3224,247 +3285,147 @@ static void do_sizing(struct window *window, int x, int y)
     if (is_ok_col_row(size_state->subwindow,
                 &rect,
                 size_state->subwindow->font_width,
-                size_state->subwindow->font_height))
-    {
+                size_state->subwindow->font_height)
+            && !SDL_RectEquals(&rect, &size_state->subwindow->sizing_rect)) {
         size_state->subwindow->sizing_rect = rect;
+        window->dirty = true;
     }
 
     size_state->originx = x;
     size_state->originy = y;
 }
 
-static void do_moving(struct window *window, int x, int y)
+static void do_moving(struct sdlpui_window *window, int x, int y)
 {
     struct move_state *move_state = &window->move_state;
+    SDL_Rect old_rect = move_state->subwindow->full_rect;
+    SDL_Rect *rect;
 
     assert(move_state->subwindow != NULL);
-
-    SDL_Rect *rect = &move_state->subwindow->full_rect;
+    rect = &move_state->subwindow->full_rect;
 
     rect->x += x - move_state->originx;
     rect->y += y - move_state->originy;
 
     try_snap(window, move_state->subwindow, rect);
     fit_rect_in_rect_by_xy(rect, &window->inner_rect);
+    if (!SDL_RectEquals(&old_rect, rect)) {
+        window->dirty = true;
+    }
 
     move_state->originx = x;
     move_state->originy = y;
 }
 
-static bool handle_menu_mousebuttonup(struct window *window,
-        const SDL_MouseButtonEvent *mouse)
-{
-    if (window->move_state.active && window->move_state.moving) {
-        window->move_state.moving = false;
-    } else if (window->size_state.active && window->size_state.sizing) {
-        window->size_state.sizing = false;
-
-        if (window->size_state.subwindow != NULL) {
-            resize_subwindow(window->size_state.subwindow);
-        }
-    } 
-    
-    if (window->move_state.active
-            || window->size_state.active
-            || is_over_status_bar(&window->status_bar, mouse->x, mouse->y))
-    {
-        return true;
-    } else {
-        return false;
-    }
-}
-
-static bool handle_menu_mousemotion(struct window *window,
+static bool handle_mousemotion(struct my_app *a,
         const SDL_MouseMotionEvent *mouse)
 {
-    if (window->move_state.moving) {
-        do_moving(window, mouse->x, mouse->y);
-        return true;
-    } else if (window->size_state.sizing) {
-        do_sizing(window, mouse->x, mouse->y);
-        return true;
-    } else if (window->move_state.active || window->size_state.active) {
-        return true;
-    } else if (is_over_status_bar(&window->status_bar, mouse->x, mouse->y)) {
-        return true;
-    }
+    struct sdlpui_dialog *d;
+    SDL_Event pendm[4];
 
-    return false;
-}
-
-static bool handle_menu_keyboard(struct window *window, const SDL_Event *event)
-{
-    if (window->move_state.active || window->size_state.active) {
-        return true;
-    }
-
-    SDL_Event key = *event;
-    /* the user pressed a key; probably wants to play? */
-    SDL_PushEvent(&key);
-
-    return false;
-}
-
-static bool handle_status_bar_buttons(struct window *window,
-        const SDL_Event *event)
-{
-    bool handled = false;
-
-    for (size_t i = 0; i < window->status_bar.button_bank.number; i++) {
-        struct button *button = &window->status_bar.button_bank.buttons[i];
-        assert(button->callbacks.on_event != NULL);
-        if (!button->disabled) {
-            handled |= button->callbacks.on_event(window, button,
-                event);
-        }
-    }
-
-    return handled;
-}
-
-static void redraw_status_bar_buttons(struct window *window)
-{
-    SDL_Event shutdown = {.type = SDL_USEREVENT};
-    (void) handle_status_bar_buttons(window, &shutdown);
-}
-
-static bool handle_menu_windowevent(struct window *window,
-        const SDL_WindowEvent *event)
-{
-    if (window->move_state.active) {
-        signal_move_state(window);
-    } else if (window->size_state.active) {
-        signal_size_state(window);
-    }
-
-    redraw_status_bar_buttons(window);
-
-    handle_windowevent(event);
-
-    return false;
-}
-
-static bool is_event_windowid_ok(const struct window *window, const SDL_Event *event)
-{
-    switch (event->type) {
-        case SDL_KEYDOWN: /* fallthru */
-        case SDL_KEYUP:
-            return event->key.windowID == window->id;
-        case SDL_TEXTINPUT:
-            return event->text.windowID == window->id;
-        case SDL_MOUSEMOTION:
-            return event->motion.windowID == window->id;
-        case SDL_MOUSEBUTTONDOWN: /* fallthru */
-        case SDL_MOUSEBUTTONUP:
-            return event->button.windowID == window->id;
-        default:
-            return true;
-    }
-}
-
-/* returns true for events that should be processed by buttons */
-static bool is_ok_button_event(const struct window *window, const SDL_Event *event)
-{
-    switch (event->type) {
-        case SDL_KEYDOWN:         /* fallthru */
-        case SDL_KEYUP:           /* fallthru */
-        case SDL_TEXTINPUT:       /* fallthru */
-            return is_event_windowid_ok(window, event);
-        case SDL_MOUSEMOTION:     /* fallthru */
-        case SDL_MOUSEBUTTONDOWN: /* fallthru */
-        case SDL_MOUSEBUTTONUP:
-            return window->focus && is_event_windowid_ok(window, event);
-        case SDL_USEREVENT:
-            return true;
-        default:
-            return false;
-    }
-}
-
-static bool handle_status_bar_events(struct window *window,
-        const SDL_Event *event)
-{
-    if (!is_event_windowid_ok(window, event)) {
-        /* just in case */
-        if (window->move_state.active) {
-            signal_move_state(window);
-        } else if (window->size_state.active) {
-            signal_size_state(window);
-        }
+    if (!a->w_mouse) {
         return false;
     }
 
-    switch (event->type) {
-        case SDL_MOUSEMOTION:
-            return handle_menu_mousemotion(window, &event->motion);
-        case SDL_MOUSEBUTTONDOWN:
-            return handle_menu_mousebuttondown(window, &event->button);
-        case SDL_MOUSEBUTTONUP:
-            return handle_menu_mousebuttonup(window, &event->button);
-        case SDL_KEYDOWN:     /* fallthru */
-        case SDL_KEYUP:       /* fallthru */
-        case SDL_TEXTEDITING: /* fallthru */
-        case SDL_TEXTINPUT:
-            return handle_menu_keyboard(window, event);
-        case SDL_WINDOWEVENT:
-            return handle_menu_windowevent(window, &event->window);
-        case SDL_QUIT:
-            handle_quit();
-            return false;
-        default:
-            return false;
-    }
-}
+    /*
+     * If more than one consecutive motion event is queued, only process
+     * the last one.
+     */
+    while (1) {
+        int npend = SDL_PeepEvents(pendm,
+            (int)(sizeof(pendm) / sizeof(pendm[0])),
+            SDL_GETEVENT, SDL_MOUSEMOTION, SDL_MOUSEMOTION);
 
-static void do_status_bar_loop(struct window *window)
-{
-    window->status_bar.in_menu = true;
-
-    bool keep_going = true;
-    while (keep_going) {
-        SDL_Delay(window->delay);
-
-        SDL_Event event;
-        SDL_WaitEvent(&event);
-
-        bool handled = false;
-        if (is_ok_button_event(window, &event)
-                && !window->move_state.moving
-                && !window->size_state.sizing)
-        {
-             handled = handle_status_bar_buttons(window, &event);
+        if (npend <= 0) {
+            if (npend < 0) {
+                SDL_LogError(SDL_LOG_CATEGORY_APPLICATION,
+                    "SDL_PeepEvents() for pending motion "
+                    "events failed: %s", SDL_GetError());
+            }
+            break;
         }
-
-        if (event.type == SDL_MOUSEMOTION) {
-            /* annoying mousemotion spam! */
-            SDL_FlushEvent(SDL_MOUSEMOTION);
-        }
-
-        if (!handled) {
-            /* so the user didnt click on a button */
-            keep_going = handle_status_bar_events(window, &event);
-        }
-
-        redraw_window(window);
+        SDL_assert(npend <= (int)(sizeof(pendm) / sizeof(pendm[0]))
+            && pendm[npend - 1].type == SDL_MOUSEMOTION);
+        mouse = &pendm[npend - 1].motion;
     }
 
-    window->status_bar.in_menu = false;
-}
-
-static bool has_visible_subwindow(const struct window *window, unsigned index)
-{
-    return get_subwindow_by_index(window, index, true) != NULL;
-}
-
-static bool handle_mousemotion(const SDL_MouseMotionEvent *mouse)
-{
-    struct window *window = get_window_by_id(mouse->windowID);
-
-    if (is_over_status_bar(&window->status_bar, mouse->x, mouse->y)) {
-        do_status_bar_loop(window);
+    if (a->w_mouse->move_state.moving) {
+        do_moving(a->w_mouse, mouse->x, mouse->y);
+        return true;
     }
-    /* dont need other mousemotion events */
-    SDL_FlushEvent(SDL_MOUSEMOTION);
+    if (a->w_mouse->size_state.sizing) {
+        do_sizing(a->w_mouse, mouse->x, mouse->y);
+        return true;
+    }
+    /* Have a menu or dialog handle the event if appropriate. */
+    if (a->w_mouse->d_mouse
+            && a->w_mouse->d_mouse->ftb->handle_mousemove
+            && (*a->w_mouse->d_mouse->ftb->handle_mousemove)(
+                a->w_mouse->d_mouse, a->w_mouse, mouse)) {
+        return true;
+    }
+
+    /*
+     * Ignore motion events while a mouse button is pressed (at
+     * least up to the point that the mouse leaves the window).
+     */
+    if (mouse->state != 0) {
+        return true;
+    }
+
+    /*
+     * Has the motion entered any of the active dialogs/menus?
+     * Check from front to back.
+     */
+    d = a->w_mouse->d_head;
+    while (1) {
+        struct sdlpui_dialog *tgt = d;
+
+        if (!tgt) {
+            break;
+        }
+        d = tgt->next;
+        if (sdlpui_is_in_dialog(tgt, mouse->x, mouse->y)) {
+            if (a->w_mouse->d_mouse != tgt) {
+                if (a->w_mouse->d_mouse &&
+                        a->w_mouse->d_mouse->ftb->handle_loses_mouse) {
+                    (*a->w_mouse->d_mouse->ftb->handle_loses_mouse)(
+                        a->w_mouse->d_mouse,
+                        a->w_mouse, mouse);
+                }
+                a->w_mouse->d_mouse = tgt;
+            }
+            /* Have key focus follow mouse. */
+            if (a->w_key != a->w_mouse) {
+                if (a->w_key && a->w_key->d_key
+                        && a->w_key->d_key->ftb->handle_loses_key) {
+                    (*a->w_key->d_key->ftb->handle_loses_key)(
+                        a->w_key->d_key, a->w_key,
+                        mouse);
+                }
+                if (a->w_key) {
+                    a->w_key->d_key = NULL;
+                }
+                SDL_assert(!a->w_key
+                    || !a->w_key->d_mouse);
+                a->w_key = a->w_mouse;
+            } else if (a->w_key->d_key && a->w_key->d_key != tgt) {
+                if (a->w_key->d_key->ftb->handle_loses_key) {
+                    (*a->w_key->d_key->ftb->handle_loses_key)(
+                        a->w_key->d_key, a->w_key,
+                        mouse);
+                }
+            }
+            a->w_mouse->d_key = tgt;
+            if (a->w_mouse->d_mouse
+                    && a->w_mouse->d_mouse->ftb->handle_mousemove
+                    && (*a->w_mouse->d_mouse->ftb->handle_mousemove)(
+                    a->w_mouse->d_mouse, a->w_mouse, mouse)) {
+                return true;
+            }
+            break;
+        }
+    }
 
     return false;
 }
@@ -3502,30 +3463,81 @@ static uint8_t translate_key_mods(Uint16 mods)
     return angband_mods;
 }
 
-static bool handle_mousebuttondown(const SDL_MouseButtonEvent *mouse)
+static bool handle_mousebutton(struct my_app *a,
+        const SDL_MouseButtonEvent *mouse)
 {
-    struct window *window = get_window_by_id(mouse->windowID);
-    assert(window != NULL);
+    struct subwindow *subwindow;
+    int button, col, row;
+    uint8_t mods;
+    term *old;
 
-    struct subwindow *subwindow = get_subwindow_by_xy(window, mouse->x, mouse->y);
-    if (subwindow == NULL) {
-        /* not an error, the user clicked in some random place */
-        return false;
-    } else if (!subwindow->top) {
-        bring_to_top(window, subwindow);
-        redraw_window(window);
+    if (!a->w_mouse) {
         return false;
     }
 
-    /* terms that are not main do not react to events, and main term
-     * lives in main window */
-    if (window->index != MAIN_WINDOW) {
+    if (a->w_mouse->move_state.active || a->w_mouse->size_state.active) {
+        if (mouse->state == SDL_RELEASED) {
+            if (a->w_mouse->move_state.active
+                    && a->w_mouse->move_state.moving) {
+                a->w_mouse->move_state.moving = false;
+                return true;
+            } else if (a->w_mouse->size_state.active
+                    && a->w_mouse->size_state.sizing) {
+                a->w_mouse->size_state.sizing = false;
+                if (a->w_mouse->size_state.subwindow) {
+                    resize_subwindow(a->w_mouse->size_state.subwindow);
+                }
+                return true;
+            }
+        } else {
+            subwindow = get_subwindow_by_xy(a->w_mouse, mouse->x,
+                mouse->y);
+            if (subwindow && is_rect_in_rect(&subwindow->full_rect,
+                    &a->w_mouse->inner_rect)) {
+                if (a->w_mouse->move_state.active
+                        && !a->w_mouse->move_state.moving) {
+                    start_moving(a->w_mouse, subwindow, mouse);
+                } else if (a->w_mouse->size_state.active
+                        && !a->w_mouse->size_state.sizing) {
+                    start_sizing(a->w_mouse, subwindow, mouse);
+                }
+                return true;
+            }
+        }
+    }
+
+    /* Have a menu or dialog handle the event if appropriate. */
+    if (a->w_mouse->d_mouse && a->w_mouse->d_mouse->ftb->handle_mouseclick
+            && (*a->w_mouse->d_mouse->ftb->handle_mouseclick)(
+                a->w_mouse->d_mouse, a->w_mouse, mouse)) {
+        return true;
+    }
+
+    /* Otherwise only react to the button press and not the release. */
+    if (mouse->state == SDL_RELEASED) {
+        return false;
+    }
+
+    subwindow = get_subwindow_by_xy(a->w_mouse, mouse->x, mouse->y);
+    if (subwindow == NULL) {
+        /* not an error, the user clicked in some random place */
+        return false;
+    }
+    if (!subwindow->top) {
+        bring_to_top(a->w_mouse, subwindow);
+        redraw_window(a->w_mouse);
+        return true;
+    }
+
+    /*
+     * Terms that are not main do not react to events, and main term
+     * lives in the main window.
+     */
+    if (a->w_mouse->index != MAIN_WINDOW) {
         return false;
     }
 
     /* all magic numbers are from ui-term.c and ui-context.c :) */
-
-    int button;
     switch (mouse->button) {
         case SDL_BUTTON_LEFT:
             button = 1;
@@ -3538,76 +3550,133 @@ static bool handle_mousebuttondown(const SDL_MouseButtonEvent *mouse)
             return false;
     }
 
-    int col;
-    int row;
     if (!get_colrow_from_xy(subwindow, mouse->x, mouse->y, &col, &row)) {
         return false;
     }
 
-    uint8_t mods = translate_key_mods(SDL_GetModState());
+    mods = translate_key_mods(SDL_GetModState());
     /* apparently mouse buttons dont get this */
     mods &= ~KC_MOD_META;
 
     button |= mods << 4;
 
-    term *old = Term;
+    old = Term;
     Term_activate(subwindow->term);
     Term_activate(old);
 
     return true;
 }
 
-static bool handle_keydown(const SDL_KeyboardEvent *key)
+static bool handle_mousewheel(struct my_app *a,
+        const SDL_MouseWheelEvent *wheel)
 {
-    uint8_t mods = translate_key_mods(key->keysym.mod);
-    keycode_t ch = 0;
-
-    /* SDL will give us both keydown and text input events in many cases.
-     * Between this function and handle_text_input we need to make sure that
-     * Term_keypress gets called exactly once for a given key press from the
-     * user.
-     * This function handles keys that don't produce text, and, if
-     * g_kp_as_mod is true, the keypad and keypresses that will produce the
-     * same characters as keypad keypresses.
-     * Others should be handled in handle_text_input.
-     */
-
-    switch (key->keysym.sym) {
-        /* arrow keys */
-        case SDLK_UP:          ch = ARROW_UP;                        break;
-        case SDLK_DOWN:        ch = ARROW_DOWN;                      break;
-        case SDLK_LEFT:        ch = ARROW_LEFT;                      break;
-        case SDLK_RIGHT:       ch = ARROW_RIGHT;                     break;
-        /* text editing keys */
-        case SDLK_BACKSPACE:   ch = KC_BACKSPACE;                    break;
-        case SDLK_PAGEDOWN:    ch = KC_PGDOWN;                       break;
-        case SDLK_PAGEUP:      ch = KC_PGUP;                         break;
-        case SDLK_INSERT:      ch = KC_INSERT;                       break;
-        case SDLK_DELETE:      ch = KC_DELETE;                       break;
-        case SDLK_RETURN:      ch = KC_ENTER;                        break;
-        case SDLK_ESCAPE:      ch = ESCAPE;                          break;
-        case SDLK_HOME:        ch = KC_HOME;                         break;
-        case SDLK_END:         ch = KC_END;                          break;
-        case SDLK_TAB:         ch = KC_TAB;                          break;
-        /* function keys */
-        case SDLK_F1:          ch = KC_F1;                           break;
-        case SDLK_F2:          ch = KC_F2;                           break;
-        case SDLK_F3:          ch = KC_F3;                           break;
-        case SDLK_F4:          ch = KC_F4;                           break;
-        case SDLK_F5:          ch = KC_F5;                           break;
-        case SDLK_F6:          ch = KC_F6;                           break;
-        case SDLK_F7:          ch = KC_F7;                           break;
-        case SDLK_F8:          ch = KC_F8;                           break;
-        case SDLK_F9:          ch = KC_F9;                           break;
-        case SDLK_F10:         ch = KC_F10;                          break;
-        case SDLK_F11:         ch = KC_F11;                          break;
-        case SDLK_F12:         ch = KC_F12;                          break;
-        case SDLK_F13:         ch = KC_F13;                          break;
-        case SDLK_F14:         ch = KC_F14;                          break;
-        case SDLK_F15:         ch = KC_F15;                          break;
+    /* Have a menu or dialog handle the event if appropriate. */
+    if (a->w_mouse && a->w_mouse->d_mouse
+            && a->w_mouse->d_mouse->ftb->handle_mousewheel
+            && (*a->w_mouse->d_mouse->ftb->handle_mousewheel)(
+                a->w_mouse->d_mouse, a->w_mouse, wheel)) {
+        return true;
     }
 
-    if (g_kp_as_mod) {
+    /* Otherwise, nothing is done. */
+    return false;
+}
+
+static bool trigger_menu_shortcut(struct my_app *a, keycode_t ch, uint8_t mods)
+{
+    /*
+     * Check if it matches a menu shortcut for an active window.  If so,
+     * give that window's menu bar key focus and return true.  Otherwise,
+     * return false.
+     */
+    int i = 0;
+
+    while (1) {
+        if (i >= MAX_WINDOWS) {
+            return false;
+        }
+        if (a->windows[i].loaded
+                && a->menu_shortcuts[i].type == EVT_KBRD
+                && a->menu_shortcuts[i].code == ch
+                && a->menu_shortcuts[i].mods == mods) {
+            if (a->w_key != a->windows + i) {
+                if (a->w_key && a->w_key->d_key
+                        && a->w_key->d_key->ftb->handle_loses_key) {
+                    (*a->w_key->d_key->ftb->handle_loses_key)(
+                        a->w_key->d_key, a->w_key, NULL);
+                }
+                if (a->w_key) {
+                    a->w_key->d_key = NULL;
+                }
+                a->w_key = a->windows + i;
+                a->w_key->d_key = a->windows[i].status_bar;
+                assert(a->w_key->d_key->ftb->goto_first_control);
+                (*a->w_key->d_key->ftb->goto_first_control)(
+                    a->w_key->d_key, a->w_key);
+            } else if (a->w_key->d_key
+                    != a->windows[i].status_bar) {
+                if (a->w_key->d_key
+                        && a->w_key->d_key->ftb->handle_loses_key) {
+                    (*a->w_key->d_key->ftb->handle_loses_key)(
+                        a->w_key->d_key, a->w_key,
+                        NULL);
+                }
+                a->w_key->d_key = a->windows[i].status_bar;
+                (*a->w_key->d_key->ftb->goto_first_control)(
+                    a->w_key->d_key, a->w_key);
+            }
+            return true;
+        }
+        ++i;
+    }
+}
+
+/*
+ * This function handles keys that don't produce text, and, if kp_as_mod
+ * the keypad and keypresses that will produce the same characters as keypad
+ * keypresses.  Others should be handled in textinput_event_to_angband_key.
+ */
+static void keyboard_event_to_angband_key(const SDL_KeyboardEvent *key,
+        bool kp_as_mod, keycode_t *ch, uint8_t *mods)
+{
+    *mods = translate_key_mods(key->keysym.mod);
+    *ch = 0;
+    switch (key->keysym.sym) {
+        /* arrow keys */
+        case SDLK_UP:          *ch = ARROW_UP; break;
+        case SDLK_DOWN:        *ch = ARROW_DOWN; break;
+        case SDLK_LEFT:        *ch = ARROW_LEFT; break;
+        case SDLK_RIGHT:       *ch = ARROW_RIGHT; break;
+        /* text editing keys */
+        case SDLK_BACKSPACE:   *ch = KC_BACKSPACE; break;
+        case SDLK_PAGEDOWN:    *ch = KC_PGDOWN; break;
+        case SDLK_PAGEUP:      *ch = KC_PGUP; break;
+        case SDLK_INSERT:      *ch = KC_INSERT; break;
+        case SDLK_DELETE:      *ch = KC_DELETE; break;
+        case SDLK_RETURN:      *ch = KC_ENTER; break;
+        case SDLK_ESCAPE:      *ch = ESCAPE; break;
+        case SDLK_HOME:        *ch = KC_HOME; break;
+        case SDLK_END:         *ch = KC_END; break;
+        case SDLK_TAB:         *ch = KC_TAB; break;
+        /* function keys */
+        case SDLK_F1:          *ch = KC_F1; break;
+        case SDLK_F2:          *ch = KC_F2; break;
+        case SDLK_F3:          *ch = KC_F3; break;
+        case SDLK_F4:          *ch = KC_F4; break;
+        case SDLK_F5:          *ch = KC_F5; break;
+        case SDLK_F6:          *ch = KC_F6; break;
+        case SDLK_F7:          *ch = KC_F7; break;
+        case SDLK_F8:          *ch = KC_F8; break;
+        case SDLK_F9:          *ch = KC_F9; break;
+        case SDLK_F10:         *ch = KC_F10; break;
+        case SDLK_F11:         *ch = KC_F11; break;
+        case SDLK_F12:         *ch = KC_F12; break;
+        case SDLK_F13:         *ch = KC_F13; break;
+        case SDLK_F14:         *ch = KC_F14; break;
+        case SDLK_F15:         *ch = KC_F15; break;
+    }
+
+    if (kp_as_mod) {
         /* If numlock is set and shift is not pressed, numpad numbers
          * produce regular numbers and not keypad numbers */
         uint8_t keypad_num_mod = ((key->keysym.mod & KMOD_NUM)
@@ -3616,166 +3685,172 @@ static bool handle_keydown(const SDL_KeyboardEvent *key)
 
         switch (key->keysym.sym) {
             /* Keypad */
-            case SDLK_KP_0: ch = '0'; mods |= keypad_num_mod; break;
-            case SDLK_KP_1: ch = '1'; mods |= keypad_num_mod; break;
-            case SDLK_KP_2: ch = '2'; mods |= keypad_num_mod; break;
-            case SDLK_KP_3: ch = '3'; mods |= keypad_num_mod; break;
-            case SDLK_KP_4: ch = '4'; mods |= keypad_num_mod; break;
-            case SDLK_KP_5: ch = '5'; mods |= keypad_num_mod; break;
-            case SDLK_KP_6: ch = '6'; mods |= keypad_num_mod; break;
-            case SDLK_KP_7: ch = '7'; mods |= keypad_num_mod; break;
-            case SDLK_KP_8: ch = '8'; mods |= keypad_num_mod; break;
-            case SDLK_KP_9: ch = '9'; mods |= keypad_num_mod; break;
+            case SDLK_KP_0:
+                *ch = '0'; *mods |= keypad_num_mod; break;
+            case SDLK_KP_1:
+                *ch = '1'; *mods |= keypad_num_mod; break;
+            case SDLK_KP_2:
+                *ch = '2'; *mods |= keypad_num_mod; break;
+            case SDLK_KP_3:
+                *ch = '3'; *mods |= keypad_num_mod; break;
+            case SDLK_KP_4:
+                *ch = '4'; *mods |= keypad_num_mod; break;
+            case SDLK_KP_5:
+                *ch = '5'; *mods |= keypad_num_mod; break;
+            case SDLK_KP_6:
+                *ch = '6'; *mods |= keypad_num_mod; break;
+            case SDLK_KP_7:
+                *ch = '7'; *mods |= keypad_num_mod; break;
+            case SDLK_KP_8:
+                *ch = '8'; *mods |= keypad_num_mod; break;
+            case SDLK_KP_9:
+                *ch = '9'; *mods |= keypad_num_mod; break;
 
             case SDLK_KP_MULTIPLY:
-                ch = '*'; mods |= KC_MOD_KEYPAD; break;
+                *ch = '*'; *mods |= KC_MOD_KEYPAD; break;
             case SDLK_KP_PERIOD:
-                ch = '.'; mods |= KC_MOD_KEYPAD; break;
+                *ch = '.'; *mods |= KC_MOD_KEYPAD; break;
             case SDLK_KP_DIVIDE:
-                ch = '/'; mods |= KC_MOD_KEYPAD; break;
+                *ch = '/'; *mods |= KC_MOD_KEYPAD; break;
             case SDLK_KP_EQUALS:
-                ch = '='; mods |= KC_MOD_KEYPAD; break;
+                *ch = '='; *mods |= KC_MOD_KEYPAD; break;
             case SDLK_KP_MINUS:
-                ch = '-'; mods |= KC_MOD_KEYPAD; break;
+                *ch = '-'; *mods |= KC_MOD_KEYPAD; break;
             case SDLK_KP_PLUS:
-                ch = '+'; mods |= KC_MOD_KEYPAD; break;
+                *ch = '+'; *mods |= KC_MOD_KEYPAD; break;
             case SDLK_KP_ENTER:
-                ch = KC_ENTER; mods |= KC_MOD_KEYPAD; break;
+                *ch = KC_ENTER; *mods |= KC_MOD_KEYPAD; break;
 
-            /* Keys that produce the same character as keypad keys */
-            case SDLK_ASTERISK: ch = '*'; break;
-            case SDLK_PLUS: ch = '+'; break;
+            /*
+             * Keys that produce the same character as keypad keys
+             */
+            case SDLK_ASTERISK: *ch = '*'; break;
+            case SDLK_PLUS: *ch = '+'; break;
         }
-        if((mods & KC_MOD_SHIFT)) {
+        if (*mods & KC_MOD_SHIFT) {
             bool match = true;
             switch(key->keysym.sym) {
-                /* Doesn't match every keyboard layout, unfortunately. */
-                case SDLK_8: ch = '*'; break;
-                case SDLK_EQUALS: ch = '+'; break;
+                /*
+                 * Does not match every keyboard layout,
+                 * unfortunately.
+                 */
+                case SDLK_8: *ch = '*'; break;
+                case SDLK_EQUALS: *ch = '+'; break;
                 default: match = false;
             }
-            if(match) {
-                mods &= ~KC_MOD_SHIFT;
+            if (match) {
+                *mods &= ~KC_MOD_SHIFT;
             }
         } else {
             switch(key->keysym.sym) {
-                case SDLK_0: ch = '0'; break;
-                case SDLK_1: ch = '1'; break;
-                case SDLK_2: ch = '2'; break;
-                case SDLK_3: ch = '3'; break;
-                case SDLK_4: ch = '4'; break;
-                case SDLK_5: ch = '5'; break;
-                case SDLK_6: ch = '6'; break;
-                case SDLK_7: ch = '7'; break;
-                case SDLK_8: ch = '8'; break;
-                case SDLK_9: ch = '9'; break;
-                case SDLK_SLASH: ch = '/'; break;
-                case SDLK_EQUALS: ch = '='; break;
-                case SDLK_PERIOD: ch = '.'; break;
-                case SDLK_MINUS: ch = '-'; break;
+                case SDLK_0: *ch = '0'; break;
+                case SDLK_1: *ch = '1'; break;
+                case SDLK_2: *ch = '2'; break;
+                case SDLK_3: *ch = '3'; break;
+                case SDLK_4: *ch = '4'; break;
+                case SDLK_5: *ch = '5'; break;
+                case SDLK_6: *ch = '6'; break;
+                case SDLK_7: *ch = '7'; break;
+                case SDLK_8: *ch = '8'; break;
+                case SDLK_9: *ch = '9'; break;
+                case SDLK_SLASH: *ch = '/'; break;
+                case SDLK_EQUALS: *ch = '='; break;
+                case SDLK_PERIOD: *ch = '.'; break;
+                case SDLK_MINUS: *ch = '-'; break;
             }
         }
     } else if (key->keysym.sym == SDLK_KP_ENTER) {
-        ch = KC_ENTER;
+        *ch = KC_ENTER;
     }
 
     /* encode control */
-    if (mods & KC_MOD_CONTROL) {
+    if (*mods & KC_MOD_CONTROL) {
         bool match = true;
         switch (key->keysym.sym) {
-            case SDLK_LEFTBRACKET:  ch = KTRL('[');  break;
-            case SDLK_RIGHTBRACKET: ch = KTRL(']');  break;
-            case SDLK_BACKSLASH:    ch = KTRL('\\'); break;
-            case SDLK_a:            ch = KTRL('A'); break;
-            case SDLK_b:            ch = KTRL('B'); break;
-            case SDLK_c:            ch = KTRL('C'); break;
-            case SDLK_d:            ch = KTRL('D'); break;
-            case SDLK_e:            ch = KTRL('E'); break;
-            case SDLK_f:            ch = KTRL('F'); break;
-            case SDLK_g:            ch = KTRL('G'); break;
-            case SDLK_h:            ch = KTRL('H'); break;
-            case SDLK_i:            ch = KTRL('I'); break;
-            case SDLK_j:            ch = KTRL('J'); break;
-            case SDLK_k:            ch = KTRL('K'); break;
-            case SDLK_l:            ch = KTRL('L'); break;
-            case SDLK_m:            ch = KTRL('M'); break;
-            case SDLK_n:            ch = KTRL('N'); break;
-            case SDLK_o:            ch = KTRL('O'); break;
-            case SDLK_p:            ch = KTRL('P'); break;
-            case SDLK_q:            ch = KTRL('Q'); break;
-            case SDLK_r:            ch = KTRL('R'); break;
-            case SDLK_s:            ch = KTRL('S'); break;
-            case SDLK_t:            ch = KTRL('T'); break;
-            case SDLK_u:            ch = KTRL('U'); break;
-            case SDLK_v:            ch = KTRL('V'); break;
-            case SDLK_w:            ch = KTRL('W'); break;
-            case SDLK_x:            ch = KTRL('X'); break;
-            case SDLK_y:            ch = KTRL('Y'); break;
-            case SDLK_z:            ch = KTRL('Z'); break;
+            case SDLK_LEFTBRACKET:  *ch = KTRL('['); break;
+            case SDLK_RIGHTBRACKET: *ch = KTRL(']'); break;
+            case SDLK_BACKSLASH:    *ch = KTRL('\\'); break;
+            case SDLK_a:            *ch = KTRL('A'); break;
+            case SDLK_b:            *ch = KTRL('B'); break;
+            case SDLK_c:            *ch = KTRL('C'); break;
+            case SDLK_d:            *ch = KTRL('D'); break;
+            case SDLK_e:            *ch = KTRL('E'); break;
+            case SDLK_f:            *ch = KTRL('F'); break;
+            case SDLK_g:            *ch = KTRL('G'); break;
+            case SDLK_h:            *ch = KTRL('H'); break;
+            case SDLK_i:            *ch = KTRL('I'); break;
+            case SDLK_j:            *ch = KTRL('J'); break;
+            case SDLK_k:            *ch = KTRL('K'); break;
+            case SDLK_l:            *ch = KTRL('L'); break;
+            case SDLK_m:            *ch = KTRL('M'); break;
+            case SDLK_n:            *ch = KTRL('N'); break;
+            case SDLK_o:            *ch = KTRL('O'); break;
+            case SDLK_p:            *ch = KTRL('P'); break;
+            case SDLK_q:            *ch = KTRL('Q'); break;
+            case SDLK_r:            *ch = KTRL('R'); break;
+            case SDLK_s:            *ch = KTRL('S'); break;
+            case SDLK_t:            *ch = KTRL('T'); break;
+            case SDLK_u:            *ch = KTRL('U'); break;
+            case SDLK_v:            *ch = KTRL('V'); break;
+            case SDLK_w:            *ch = KTRL('W'); break;
+            case SDLK_x:            *ch = KTRL('X'); break;
+            case SDLK_y:            *ch = KTRL('Y'); break;
+            case SDLK_z:            *ch = KTRL('Z'); break;
             default: match = false;
         }
-        if(match) {
-            mods &= ~KC_MOD_CONTROL;
+        if (match) {
+            *mods &= ~KC_MOD_CONTROL;
         }
     }
+}
 
+static bool handle_key(struct my_app *a, const SDL_KeyboardEvent *key)
+{
+    uint8_t mods;
+    keycode_t ch;
 
-    if (ch) {
-        Term_keypress(ch, mods);
+    /* Have a menu or dialog handle the event if appropriate. */
+    if (a->w_key && a->w_key->d_key && a->w_key->d_key->ftb->handle_key
+            && (*a->w_key->d_key->ftb->handle_key)(a->w_key->d_key,
+                a->w_key, key)) {
         return true;
-    } else {
+    }
+
+    /*
+     * For passing events to the game's core, react when the button is
+     * pressed and not when it is released.
+     */
+    if (key->state == SDL_RELEASED) {
         return false;
     }
-}
 
-static keycode_t utf8_to_codepoint(const char *utf8_string)
-{
-    /* hex  == binary
-     * 0x00 == 00000000
-     * 0x80 == 10000000
-     * 0xc0 == 11000000
-     * 0xe0 == 11100000
-     * 0xf0 == 11110000
-     * 0xf8 == 11111000
-     * 0x3f == 00111111
-     * 0x1f == 00011111
-     * 0x0f == 00001111
-     * 0x07 == 00000111 */
-
-    keycode_t key = 0;
-
-#define IS_UTF8_INFO(mask, result) (((unsigned char) utf8_string[0] & (mask)) == (result))
-#define EXTRACT_UTF8_INFO(pos, mask, shift) (((unsigned char) utf8_string[(pos)] & (mask)) << (shift))
-    /* 6 is the number of information bits in a utf8 continuation byte (10xxxxxx) */
-    if (IS_UTF8_INFO(0x80, 0)) {
-        key = utf8_string[0];
-    } else if (IS_UTF8_INFO(0xe0, 0xc0)) {
-        key = EXTRACT_UTF8_INFO(0, 0x1f, 6)
-            | EXTRACT_UTF8_INFO(1, 0x3f, 0);
-    } else if (IS_UTF8_INFO(0xf0, 0xe0)) {
-        key = EXTRACT_UTF8_INFO(0, 0x0f, 12)
-            | EXTRACT_UTF8_INFO(1, 0x3f, 6)
-            | EXTRACT_UTF8_INFO(2, 0x3f, 0);
-    } else if (IS_UTF8_INFO(0xf8, 0xf0)) {
-        key = EXTRACT_UTF8_INFO(0, 0x07, 18)
-            | EXTRACT_UTF8_INFO(1, 0x3f, 12)
-            | EXTRACT_UTF8_INFO(2, 0x3f, 6)
-            | EXTRACT_UTF8_INFO(3, 0x3f, 0);
+    /*
+     * SDL will give us both keydown and text input events in many cases.
+     * Between this function and handle_text_input we need to make sure that
+     * Term_keypress gets called exactly once for a given key press from the
+     * user.
+     */
+    keyboard_event_to_angband_key(key, a->kp_as_mod, &ch, &mods);
+    if (ch) {
+        if (!trigger_menu_shortcut(a, ch, mods)) {
+            Term_keypress(ch, mods);
+        }
+        return true;
     }
-#undef IS_UTF8_INFO
-#undef EXTRACT_UTF8_INFO
-
-    return key;
+    return false;
 }
 
-static bool handle_text_input(const SDL_TextInputEvent *input)
+static void textinput_event_to_angband_key(const SDL_TextInputEvent *input,
+        bool kp_as_mod, keycode_t *ch, uint8_t *mods)
 {
-    keycode_t ch = utf8_to_codepoint(input->text);
+    *ch = sdlpui_utf8_to_codepoint(input->text);
 
-    /* Don't handle any characters that can be produced by the keypad if
-     * they were handled in handle_keydown */
-    if (g_kp_as_mod) {
-        switch (ch) {
+    /*
+     * Do not handle any characters that can be produced by the keypad if
+     * they were handled in keyboard_event_to_angband_key.
+     */
+    if (kp_as_mod) {
+        switch (*ch) {
             case '0':
             case '1':
             case '2':
@@ -3792,23 +3867,55 @@ static bool handle_text_input(const SDL_TextInputEvent *input)
             case '+':
             case '.':
             case '=':
-                return false;
+                *ch = '\0';
         }
     }
 
-    uint8_t mods = translate_key_mods(SDL_GetModState());
-
+    *mods = translate_key_mods(SDL_GetModState());
     /* Shift is already encoded in characters we receive here */
-    if (!MODS_INCLUDE_SHIFT(ch)) {
-        mods &= ~KC_MOD_SHIFT;
+    if (!MODS_INCLUDE_SHIFT(*ch)) {
+        *mods &= ~KC_MOD_SHIFT;
+    }
+}
+
+static bool handle_text_input(struct my_app *a, const SDL_TextInputEvent *input)
+{
+    keycode_t ch;
+    uint8_t mods;
+
+    /* Have a menu or dialog handle the event if appropriate. */
+    if (a->w_key && a->w_key->d_key && a->w_key->d_key->ftb->handle_textin
+            && (*a->w_key->d_key->ftb->handle_textin)(
+                a->w_key->d_key, a->w_key, input)) {
+        return true;
     }
 
-    Term_keypress(ch, mods);
+    textinput_event_to_angband_key(input, a->kp_as_mod, &ch, &mods);
 
+    if (!ch) {
+        return false;
+    }
+    if (!trigger_menu_shortcut(a, ch, mods)) {
+        Term_keypress(ch, mods);
+    }
     return true;
 }
 
-static void wait_anykey(void)
+static bool handle_text_editing(struct my_app *a,
+        const SDL_TextEditingEvent *edit)
+{
+    /* Have a menu or dialog handle the event if appropriate. */
+    if (a->w_key && a->w_key->d_key && a->w_key->d_key->ftb->handle_textedit
+            && (*a->w_key->d_key->ftb->handle_textedit)(
+                a->w_key->d_key, a->w_key, edit)) {
+        return true;
+    }
+
+    /* Not passed on to the game's core. */
+    return false;
+}
+
+static void wait_anykey(struct my_app *a)
 {
     SDL_Event event;
 
@@ -3822,7 +3929,7 @@ static void wait_anykey(void)
         switch (event.type) {
             case SDL_KEYDOWN:
                 expected = SDL_KEYUP;
-                break;;
+                break;
             case SDL_MOUSEBUTTONDOWN:
                 expected = SDL_MOUSEBUTTONUP;
                 break;
@@ -3833,7 +3940,7 @@ static void wait_anykey(void)
                 handle_quit();
                 break;
             case SDL_WINDOWEVENT:
-                handle_windowevent(&event.window);
+                handle_windowevent(a, &event.window);
                 return;
         }
     }
@@ -3841,10 +3948,11 @@ static void wait_anykey(void)
 
 static void handle_quit(void)
 {
+    /* Quit */
     quit(NULL);
 }
 
-static bool get_event(void)
+static bool get_event(struct my_app *a)
 {
     SDL_Event event;
     if (!SDL_PollEvent(&event)) {
@@ -3853,15 +3961,21 @@ static bool get_event(void)
 
     switch (event.type) {
         case SDL_KEYDOWN:
-            return handle_keydown(&event.key);
+        case SDL_KEYUP:
+            return handle_key(a, &event.key);
         case SDL_TEXTINPUT:
-            return handle_text_input(&event.text);
+            return handle_text_input(a, &event.text);
+        case SDL_TEXTEDITING:
+            return handle_text_editing(a, &event.edit);
         case SDL_MOUSEMOTION:
-            return handle_mousemotion(&event.motion);
+            return handle_mousemotion(a, &event.motion);
         case SDL_MOUSEBUTTONDOWN:
-            return handle_mousebuttondown(&event.button);
+        case SDL_MOUSEBUTTONUP:
+            return handle_mousebutton(a, &event.button);
+        case SDL_MOUSEWHEEL:
+            return handle_mousewheel(a, &event.wheel);
         case SDL_WINDOWEVENT:
-            handle_windowevent(&event.window);
+            handle_windowevent(a, &event.window);
             return false;
         case SDL_QUIT:
             handle_quit();
@@ -3871,7 +3985,7 @@ static bool get_event(void)
     }
 }
 
-static void refresh_angband_terms(void)
+static void refresh_angband_terms(struct my_app *a)
 {
     if (!Setup.initialized) {
         return;
@@ -3897,7 +4011,7 @@ static void refresh_angband_terms(void)
 
     Term_activate(old);
 
-    redraw_all_windows(false);
+    redraw_all_windows(a, false);
 }
 
 static errr term_xtra_event(int v)
@@ -3905,19 +4019,26 @@ static errr term_xtra_event(int v)
     struct subwindow *subwindow = Term->data;
     assert(subwindow != NULL);
 
-    redraw_all_windows(true);
+    /* Hack -- Check if the main window is unloaded. quit_hook() free resources */
+    if (!g_app.windows[0].loaded) {
+        /* Delay 100ms */
+        SDL_Delay(100);
+        return 0;
+    }
+
+    redraw_all_windows(subwindow->app, true);
 
     if (v) {
         while (true) {
             for (int i = 0; i < DEFAULT_IDLE_UPDATE_PERIOD; i++) {
-                if (get_event()) {
+                if (get_event(subwindow->app)) {
                     return 0;
                 }
                 SDL_Delay(subwindow->window->delay);
             }
         }
     } else {
-        (void) get_event();
+        (void) get_event(subwindow->app);
     }
 
     return 0;
@@ -3930,7 +4051,7 @@ static errr term_xtra_flush(void)
     while (SDL_PollEvent(&event)) {
         switch (event.type) {
             case SDL_WINDOWEVENT:
-                handle_windowevent(&event.window);
+                handle_windowevent(&g_app, &event.window);
                 break;
         }
     }
@@ -3956,7 +4077,7 @@ static errr term_xtra_fresh(void)
     struct subwindow *subwindow = Term->data;
     assert(subwindow != NULL);
 
-    if (!subwindow->window->status_bar.in_menu) {
+    if (!subwindow->window->d_mouse && !subwindow->window->d_key) {
         try_redraw_window(subwindow->window);
     }
 
@@ -3975,7 +4096,7 @@ static errr term_xtra_delay(int v)
 
 static errr term_xtra_react(void)
 {
-    init_colors();
+    init_colors(&g_app);
 
     return 0;
 }
@@ -4016,7 +4137,8 @@ static errr term_curs_hook(int col, int row)
 
     /* Highlight party members */
     for (int i = 0; Term->minimap_active && (i < party_n); i++)
-        render_cursor_aux(subwindow, party_x[i] + COL_MAP, party_y[i] + ROW_MAP, false, g_colors[COLOUR_L_BLUE]);
+        render_cursor_aux(subwindow, party_x[i] + COL_MAP, party_y[i] + ROW_MAP,
+            false, subwindow->app->colors[COLOUR_L_BLUE]);
 
     subwindow->window->dirty = true;
 
@@ -4059,7 +4181,7 @@ static errr term_text_hook(int col, int row, int n, uint16_t a, const char *s)
     struct subwindow *subwindow = Term->data;
     assert(subwindow != NULL);
 
-    SDL_Color fg = g_colors[a % MAX_COLORS];
+    SDL_Color fg = subwindow->app->colors[a % MAX_COLORS];
     SDL_Color bg;
 
     switch (a / MULT_BG) {
@@ -4070,11 +4192,11 @@ static errr term_text_hook(int col, int row, int n, uint16_t a, const char *s)
             bg = fg;
             break;
         case BG_DARK:
-            bg = g_colors[DEFAULT_SHADE_COLOR];
+            bg = subwindow->app->colors[DEFAULT_SHADE_COLOR];
             break;
         default:
             /* debugging */
-            bg = g_colors[DEFAULT_ERROR_COLOR];
+            bg = subwindow->app->colors[DEFAULT_ERROR_COLOR];
             break;
     }
 
@@ -4111,12 +4233,11 @@ static errr term_pict_hook(int col, int row, int n,
     if (!current_graphics_mode || current_graphics_mode->grafID == GRAPHICS_NONE) {
         /*
          * Do nothing unsuccessfully if asked to draw a tile while
-         * they're not enabled. Could proceed in this function
+         * they're not enabled.  Could proceed in this function
          * with no apparent ill effects, but that just wastes time.
          */
         return -1;
     }
-
     assert(subwindow->window->graphics.texture != NULL);
 
     for (int i = 0; i < n; i++) {
@@ -4170,7 +4291,7 @@ static void term_view_map_shared(struct subwindow *subwindow,
 
     SDL_RenderPresent(subwindow->window->renderer);
 
-    wait_anykey();
+    wait_anykey(subwindow->app);
 }
 
 static void term_view_map_tile(struct subwindow *subwindow)
@@ -4211,7 +4332,7 @@ static void term_view_map_tile(struct subwindow *subwindow)
 
     /* render cursor around player */
     render_outline_rect_width(subwindow->window,
-            map, &cursor, &g_colors[DEFAULT_SUBWINDOW_CURSOR_COLOR],
+            map, &cursor, &subwindow->app->colors[DEFAULT_SUBWINDOW_CURSOR_COLOR],
             /* XXX some arbitrary values that look ok at the moment */
             MIN(MIN(tile.w / 4, tile.h / 4),
                 DEFAULT_VISIBLE_BORDER));
@@ -4223,7 +4344,7 @@ static void term_view_map_tile(struct subwindow *subwindow)
                                  tile.h};
 
         render_outline_rect_width(subwindow->window,
-            map, &cursor_party, &g_colors[COLOUR_L_BLUE],
+            map, &cursor_party, &subwindow->app->colors[COLOUR_L_BLUE],
             /* XXX some arbitrary values that look ok at the moment */
             MIN(MIN(tile.w / 4, tile.h / 4),
                 DEFAULT_VISIBLE_BORDER));
@@ -4263,7 +4384,7 @@ static void term_view_map_text(struct subwindow *subwindow)
 
     /* render cursor around player */
     render_outline_rect_width(subwindow->window,
-            map, &cursor, &g_colors[DEFAULT_SUBWINDOW_CURSOR_COLOR],
+            map, &cursor, &subwindow->app->colors[DEFAULT_SUBWINDOW_CURSOR_COLOR],
             /* XXX some arbitrary values that look reasonable at the moment */
             MIN(MIN(subwindow->font_width / 4,
                     subwindow->font_height / 4),
@@ -4280,7 +4401,7 @@ static void term_view_map_text(struct subwindow *subwindow)
         };
 
         render_outline_rect_width(subwindow->window,
-            map, &cursor_party, &g_colors[COLOUR_L_BLUE],
+            map, &cursor_party, &subwindow->app->colors[COLOUR_L_BLUE],
             /* XXX some arbitrary values that look reasonable at the moment */
             MIN(MIN(subwindow->font_width / 4,
                     subwindow->font_height / 4),
@@ -4308,7 +4429,8 @@ static void term_view_map_hook(term *terminal)
     }
 }
 
-static SDL_Texture *load_image(const struct window *window, const char *path)
+static SDL_Texture *load_image(const struct sdlpui_window *window,
+        const char *path)
 {
     SDL_Surface *surface = IMG_Load(path);
     if (surface == NULL) {
@@ -4323,7 +4445,7 @@ static SDL_Texture *load_image(const struct window *window, const char *path)
     return texture;
 }
 
-static void load_wallpaper(struct window *window, const char *path)
+static void load_wallpaper(struct sdlpui_window *window, const char *path)
 {
     if (window->wallpaper.mode == WALLPAPER_DONT_SHOW) {
         return;
@@ -4370,7 +4492,7 @@ static void load_wallpaper(struct window *window, const char *path)
     }
 }
 
-static void load_default_wallpaper(struct window *window)
+static void load_default_wallpaper(struct sdlpui_window *window)
 {
     if (window->wallpaper.mode == WALLPAPER_DONT_SHOW) {
         return;
@@ -4382,66 +4504,7 @@ static void load_default_wallpaper(struct window *window)
     load_wallpaper(window, path);
 }
 
-static void load_stipple(struct window *window)
-{
-    SDL_Surface *s;
-    Uint32 *pixels;
-    Uint32 rmask, gmask, bmask, amask, on_pixel, off_pixel;
-    int y, x;
-
-    /*
-     * on_pixel is black and completely transparent.  off_pixel is gray
-     * (0x40, 0x40, 0x40) and slightly opaque.
-     */
-#if SDL_BYTEORDER == SDL_BIG_ENDIAN
-    rmask = 0xff000000;
-    gmask = 0x00ff0000;
-    bmask = 0x0000ff00;
-    amask = 0x000000ff;
-    on_pixel = 0x000000ff;
-    off_pixel = 0x40404040;
-#else
-    rmask = 0x000000ff;
-    gmask = 0x0000ff00;
-    bmask = 0x00ff0000;
-    amask = 0xff000000;
-    on_pixel = 0xff000000;
-    off_pixel = 0x40404040;
-#endif
-
-    /*
-     * These dimensions must be multiple of two:  see the loop logic below.
-     */
-    window->stipple.h = 16;
-    window->stipple.w = 16;
-    pixels = mem_alloc(window->stipple.h * window->stipple.w *
-        sizeof(*pixels));
-    for (y = 0; y < window->stipple.h; y += 2) {
-        uint32_t *row = pixels + y * window->stipple.w;
-
-        for (x = 0; x < window->stipple.w; x += 2) {
-            row[x] = on_pixel;
-            row[x + 1] = off_pixel;
-            row[x + window->stipple.w] = off_pixel;
-            row[x + window->stipple.w + 1] = on_pixel;
-        }
-    }
-
-    s = SDL_CreateRGBSurfaceFrom(pixels, window->stipple.w,
-        window->stipple.h, 32, 4 * window->stipple.w, rmask, gmask,
-        bmask, amask);
-    window->stipple.texture = SDL_CreateTextureFromSurface(window->renderer,
-        s);
-    if (window->stipple.texture == NULL) {
-        (void) fprintf(stderr, "could not create stipple texture: %s\n",
-            SDL_GetError());
-    }
-
-    SDL_FreeSurface(s);
-    mem_free(pixels);
-}
-
-static void load_default_window_icon(const struct window *window)
+static void load_default_window_icon(const struct sdlpui_window *window)
 {
     char path[4096];
     path_build(path, sizeof(path), DEFAULT_WINDOW_ICON_DIR, DEFAULT_WINDOW_ICON);
@@ -4454,7 +4517,7 @@ static void load_default_window_icon(const struct window *window)
     SDL_FreeSurface(surface);
 }
 
-static void load_graphics(struct window *window, graphics_mode *mode)
+static void load_graphics(struct sdlpui_window *window, graphics_mode *mode)
 {
     assert(window->graphics.texture == NULL);
 
@@ -4492,14 +4555,14 @@ static void load_graphics(struct window *window, graphics_mode *mode)
     window->graphics.id = mode->grafID;
 }
 
-static void reload_all_graphics(graphics_mode *mode)
+static void reload_all_graphics(struct my_app *a, graphics_mode *mode)
 {
     if (mode == NULL) {
         return;
     }
 
     for (size_t i = 0; i < MAX_WINDOWS; i++) {
-        struct window *window = get_window_direct(i);
+        struct sdlpui_window *window = get_window_direct(a, i);
         if (window == NULL) {
             continue;
         }
@@ -4512,18 +4575,22 @@ static void reload_all_graphics(graphics_mode *mode)
     }
 }
 
-static const struct font_info *find_font_info(const char *name)
+static const struct font_info *find_font_info(const struct font_info *fonts,
+        int nfonts, const char *name)
 {
-    for (size_t i = 0; i < N_ELEMENTS(g_font_info); i++) {
-        if (g_font_info[i].loaded && streq(g_font_info[i].name, name)) {
-            return &g_font_info[i];
+    int i;
+
+    for (i = 0; i < nfonts; i++) {
+        if (streq(fonts[i].name, name)) {
+            return &fonts[i];
         }
     }
 
     return NULL;
 }
 
-static void make_font_cache(const struct window *window, struct font *font)
+static void make_font_cache(const struct sdlpui_window *window,
+        struct font *font)
 {
     font->cache.texture = make_subwindow_texture(window,
             (int) ASCII_CACHE_SIZE * font->ttf.glyph.w, font->ttf.glyph.h);
@@ -4568,10 +4635,11 @@ static void make_font_cache(const struct window *window, struct font *font)
     }
 }
 
-static struct font *make_font(const struct window *window,
+static struct font *make_font(const struct sdlpui_window *window,
         const char *name, int size)
 {
-    const struct font_info *info = find_font_info(name);
+    const struct font_info *info = find_font_info(window->app->fonts,
+        window->app->font_count, name);
     if (info == NULL) {
         return NULL;
     }
@@ -4599,23 +4667,9 @@ static bool reload_font(struct subwindow *subwindow,
         return false;
     }
 
-    subwindow->sizing_rect = subwindow->full_rect;
-    if (!is_ok_col_row(subwindow,
-                &subwindow->sizing_rect, new_font->ttf.glyph.w, new_font->ttf.glyph.h))
-    {
-        int min_cols = subwindow->index == MAIN_SUBWINDOW ? MIN_COLS_MAIN : MIN_COLS_OTHER;
-        int min_rows = subwindow->index == MAIN_SUBWINDOW ? MIN_ROWS_MAIN : MIN_ROWS_OTHER;
-
-        subwindow->sizing_rect.w = min_cols * new_font->ttf.glyph.w + 2 * DEFAULT_BORDER;
-        subwindow->sizing_rect.h = min_rows * new_font->ttf.glyph.h + 2 * DEFAULT_BORDER;
-    }
-
-    if (subwindow->sizing_rect.w > subwindow->window->inner_rect.w
-            || subwindow->sizing_rect.h > subwindow->window->inner_rect.h)
-    {
+    if (!is_usable_font_for_subwindow(new_font, subwindow,
+            &subwindow->sizing_rect)) {
         free_font(new_font);
-        memset(&subwindow->sizing_rect, 0, sizeof(subwindow->sizing_rect));
-
         return false;
     }
 
@@ -4692,7 +4746,7 @@ static bool is_ok_col_row(const struct subwindow *subwindow,
     return true;
 }
 
-static bool adjust_subwindow_geometry(const struct window *window,
+static bool adjust_subwindow_geometry(const struct sdlpui_window *window,
         struct subwindow *subwindow)
 {
     if (!subwindow->loaded && subwindow->config == NULL) {
@@ -4745,9 +4799,9 @@ static bool adjust_subwindow_geometry(const struct window *window,
     return true;
 }
 
-static void sort_to_top_aux(struct window *window, size_t *next_subwindow,
-        struct subwindow **subwindows, size_t num_subwindows,
-        bool top, bool always_top)
+static void sort_to_top_aux(struct sdlpui_window *window,
+        size_t *next_subwindow, struct subwindow **subwindows,
+        size_t num_subwindows, bool top, bool always_top)
 {
     if (*next_subwindow == num_subwindows) {
         return;
@@ -4765,7 +4819,7 @@ static void sort_to_top_aux(struct window *window, size_t *next_subwindow,
     assert(*next_subwindow <= num_subwindows);
 }
 
-static void sort_to_top(struct window *window)
+static void sort_to_top(struct sdlpui_window *window)
 {
     struct subwindow *tmp[N_ELEMENTS(window->subwindows)] = {NULL};
     assert(sizeof(window->subwindows) == sizeof(tmp));
@@ -4787,7 +4841,8 @@ static void sort_to_top(struct window *window)
     memcpy(window->subwindows, tmp, sizeof(window->subwindows));
 }
 
-static void bring_to_top(struct window *window, struct subwindow *subwindow)
+static void bring_to_top(struct sdlpui_window *window,
+        struct subwindow *subwindow)
 {
     assert(subwindow->window == window);
 
@@ -4807,23 +4862,25 @@ static void bring_to_top(struct window *window, struct subwindow *subwindow)
     sort_to_top(window);
 }
 
-static void adjust_status_bar_geometry(struct window *window)
+static void adjust_status_bar_geometry(struct sdlpui_window *window)
 {
-    struct status_bar *status_bar = &window->status_bar;
+    int mw, mh;
 
-    status_bar->full_rect.x = 0;
-    status_bar->full_rect.y = 0;
-    status_bar->full_rect.w = window->full_rect.w;
-    status_bar->full_rect.h = DEFAULT_LINE_HEIGHT(status_bar->font->ttf.glyph.h);
-    status_bar->inner_rect = status_bar->full_rect;
-
-    int border = (status_bar->full_rect.h - status_bar->font->ttf.glyph.h) / 2;
-    resize_rect(&status_bar->inner_rect,
-            border, border, -border, -border);
+    (*window->status_bar->ftb->query_minimum_size)(window->status_bar,
+        window, &mw, &mh);
+    assert(mw <= window->full_rect.w);
+    if (window->status_bar->ftb->resize) {
+        (*window->status_bar->ftb->resize)(window->status_bar, window,
+            window->full_rect.w, mh);
+    } else {
+        window->status_bar->rect.w = window->full_rect.w;
+        window->status_bar->rect.h = mh;
+    }
 }
 
-static struct subwindow *get_subwindow_by_index(const struct window *window,
-        unsigned index, bool visible)
+static struct subwindow *get_subwindow_by_index(
+        const struct sdlpui_window *window, unsigned index,
+        bool visible)
 {
     for (size_t i = 0; i < N_ELEMENTS(window->subwindows); i++) {
         struct subwindow *subwindow = window->subwindows[i];
@@ -4839,7 +4896,8 @@ static struct subwindow *get_subwindow_by_index(const struct window *window,
     return NULL;
 }
 
-static struct subwindow *get_subwindow_by_xy(const struct window *window, int x, int y)
+static struct subwindow *get_subwindow_by_xy(
+        const struct sdlpui_window *window, int x, int y)
 {
     /* checking subwindows in z order */
     for (size_t i = N_ELEMENTS(window->subwindows); i > 0; i--) {
@@ -4855,44 +4913,17 @@ static struct subwindow *get_subwindow_by_xy(const struct window *window, int x,
     return NULL;
 }
 
-static struct menu_panel *get_menu_panel_by_xy(struct menu_panel *menu_panel,
-        int x, int y)
+static void handle_button_open_subwindow(struct sdlpui_control *ctrl,
+        struct sdlpui_dialog *dlg, struct sdlpui_window *window)
 {
-    while (menu_panel != NULL) {
-        if (is_point_in_rect(x, y, &menu_panel->rect)) {
-            return menu_panel;
-        }
-        menu_panel = menu_panel->next;
-    }
+    int tag;
+    unsigned int index;
+    struct subwindow *subwindow;
 
-    return NULL;
-}
-
-static bool is_over_status_bar(const struct status_bar *status_bar, int x, int y)
-{
-    return is_point_in_rect(x, y, &status_bar->full_rect);
-}
-
-static void make_button_bank(struct button_bank *bank)
-{
-    bank->buttons = mem_zalloc(sizeof(*bank->buttons) * MAX_BUTTONS);
-
-    bank->size = MAX_BUTTONS;
-    bank->number = 0;
-}
-
-static bool handle_button_open_subwindow(struct window *window,
-        struct button *button, const SDL_Event *event)
-{
-    CHECK_BUTTON_DATA_TYPE(button, BUTTON_DATA_UNSIGNED);
-
-    if (!click_status_bar_button(window, button, event)) {
-        return false;
-    }
-
-    unsigned index = button->data.value.unsigned_value;
-    struct subwindow *subwindow = NULL;
-
+    assert(ctrl->ftb->get_tag);
+    tag = (*ctrl->ftb->get_tag)(ctrl);
+    assert(tag >= 0);
+    index = (unsigned int)tag;
     subwindow = get_subwindow_by_index(window, index, false);
     if (subwindow != NULL) {
         subwindow->visible = !subwindow->visible;
@@ -4913,11 +4944,11 @@ static bool handle_button_open_subwindow(struct window *window,
         if (subwindow->visible) {
             bring_to_top(window, subwindow);
         }
-    } else if (is_subwindow_loaded(index)) {
+    } else if (is_subwindow_loaded(window->app, index)) {
         subwindow = transfer_subwindow(window, index);
         subwindow->visible = true;
         bring_to_top(window, subwindow);
-        refresh_angband_terms();
+        refresh_angband_terms(subwindow->app);
     } else {
         subwindow = make_subwindow(window, index);
         assert(subwindow != NULL);
@@ -4926,190 +4957,102 @@ static bool handle_button_open_subwindow(struct window *window,
         subwindows_reinit_flags();
         /* Set up the subwindows */
         subwindows_init_flags();
-        refresh_angband_terms();
+        refresh_angband_terms(subwindow->app);
     }
 
-    redraw_all_windows(false);
-
-    return true;
+    redraw_all_windows(subwindow->app, false);
 }
 
-static void close_status_bar_menu(struct status_bar *status_bar)
+static void close_status_bar_menu(struct sdlpui_window *window)
 {
-    if (status_bar->menu_panel != NULL) {
-        free_menu_panel(status_bar->menu_panel);
-        status_bar->menu_panel = NULL;
+    sdlpui_popdown_dialog(window->status_bar, window, false);
+    window->status_bar = NULL;
+    window->move_button = NULL;
+    window->size_button = NULL;
+}
+
+static void load_status_bar(struct sdlpui_window *window)
+{
+    struct sdlpui_control *c;
+    unsigned int i;
+    int w, h;
+
+    window->status_bar = sdlpui_start_simple_menu(NULL, NULL,
+        2 + N_ELEMENTS(window->subwindows)
+        + ((window->index == MAIN_WINDOW) ? 1 : 0), false, true,
+        NULL, 0);
+    c = sdlpui_get_simple_menu_next_unused(window->status_bar,
+        SDLPUI_MFLG_NONE);
+    sdlpui_create_submenu_button(c, "Menu", SDLPUI_HOR_CENTER,
+        handle_menu_button, SDLPUI_CHILD_MENU_BELOW, 0, false);
+    if (window->index == MAIN_WINDOW) {
+        /*
+         * For symmetry with the other windows, give the main window
+         * an entry in the menu.  As the main window is always visible
+         * while the application is hidden, that entry does not allow
+         * interaction.
+         */
+        c = sdlpui_get_simple_menu_next_unused(window->status_bar,
+            SDLPUI_MFLG_CAN_HIDE);
+        sdlpui_create_menu_indicator(c, "A", SDLPUI_HOR_CENTER, 0,
+            true);
     }
-}
+    for (i = 1; i < (unsigned int)N_ELEMENTS(window->subwindows); ++i) {
+        struct subwindow *subw =
+            get_subwindow_by_index(window, i, false);
 
-static void make_default_status_buttons(struct status_bar *status_bar)
-{
-    SDL_Rect rect;
-    struct button_data data;
-    struct button_callbacks callbacks;
-
-#define PUSH_BUTTON_LEFT_TO_RIGHT(cap) \
-    get_string_metrics(status_bar->font, (cap), &rect.w, NULL); \
-    rect.w += DEFAULT_BUTTON_BORDER * 2; \
-    push_button(&status_bar->button_bank, status_bar->font, \
-            (cap), false, data, callbacks, &rect, CAPTION_POSITION_CENTER); \
-    rect.x += rect.w; \
-
-    rect.x = status_bar->full_rect.x;
-    rect.y = status_bar->full_rect.y;
-    rect.w = 0;
-    rect.h = status_bar->full_rect.h;
-
-    callbacks.on_render = render_menu_button;
-    callbacks.on_event = handle_menu_button;
-    callbacks.on_menu = NULL;
-
-    data.type = BUTTON_DATA_NONE;
-    PUSH_BUTTON_LEFT_TO_RIGHT("Menu");
-
-    callbacks.on_render = render_button_subwindows;
-
-    data.type = BUTTON_DATA_UNSIGNED;
-
-    if (status_bar->window->index == MAIN_WINDOW) {
-        /* "A" button is not interactive, it's just for display */
-        callbacks.on_event = ignore_status_bar_button;
-        data.value.unsigned_value = MAIN_SUBWINDOW;
-        /* the main term is called Angband in game options */
-        PUSH_BUTTON_LEFT_TO_RIGHT("A");
+        c = sdlpui_get_simple_menu_next_unused(window->status_bar,
+            SDLPUI_MFLG_CAN_HIDE);
+        sdlpui_create_menu_toggle(c, (i == CHAT_SUBWINDOW) ? "C" : format("%u", i),
+            SDLPUI_HOR_CENTER, handle_button_open_subwindow,
+            (int)i, false, subw && subw->visible);
     }
-
-    callbacks.on_event = handle_button_open_subwindow;
-    for (unsigned i = 1; i < N_ELEMENTS(status_bar->window->subwindows); i++) {
-        data.value.unsigned_value = i;
-        /* Chat window */
-        if (i == CHAT_SUBWINDOW) {
-            PUSH_BUTTON_LEFT_TO_RIGHT("C");
-            continue;
-        }
-        PUSH_BUTTON_LEFT_TO_RIGHT(format("%u", i));
-    }
-#undef PUSH_BUTTON_LEFT_TO_RIGHT
-
-#define PUSH_BUTTON_RIGHT_TO_LEFT(cap) \
-    get_string_metrics(status_bar->font, (cap), &rect.w, NULL); \
-    rect.w += DEFAULT_BUTTON_BORDER * 2; \
-    rect.x -= rect.w; \
-    push_button(&status_bar->button_bank, status_bar->font, \
-            (cap), false, data, callbacks, &rect, CAPTION_POSITION_CENTER); \
-
-    rect.x = status_bar->full_rect.x + status_bar->full_rect.w;
-    rect.y = status_bar->full_rect.y;
-    rect.w = 0;
-    rect.h = status_bar->full_rect.h;
-
-    callbacks.on_render = render_button_movesize;
-    callbacks.on_event = handle_button_movesize;
-    callbacks.on_menu = NULL;
-
-    data.type = BUTTON_DATA_INT;
-
-    data.value.int_value = BUTTON_MOVESIZE_MOVING;
-    PUSH_BUTTON_RIGHT_TO_LEFT("Move");
-
-    data.value.int_value = BUTTON_MOVESIZE_SIZING;
-    PUSH_BUTTON_RIGHT_TO_LEFT("Size");
-#undef PUSH_BUTTON_RIGHT_TO_LEFT
-}
-
-static void reload_status_bar(struct status_bar *status_bar)
-{
-    close_status_bar_menu(status_bar);
-
-    SDL_DestroyTexture(status_bar->texture);
-    status_bar->texture = make_subwindow_texture(status_bar->window,
-            status_bar->full_rect.w, status_bar->full_rect.h);
-    assert(status_bar->texture != NULL);
-
-    free_button_bank(&status_bar->button_bank);
-    make_button_bank(&status_bar->button_bank);
-    make_default_status_buttons(status_bar);
-
-    render_status_bar(status_bar->window);
-}
-
-static void load_status_bar(struct window *window)
-{
-    if (window->status_bar.font == NULL) {
-        const char *try_names[3];
-        int try_sizes[3];
-        int n_tries = 0, i = 0;
-
-        if (window->config && window->config->font_name) {
-            try_names[n_tries] = window->config->font_name;
-            try_sizes[n_tries] = window->config->font_size;
-            ++n_tries;
-        }
-        try_names[n_tries] = DEFAULT_STATUS_BAR_FONT;
-        try_sizes[n_tries] = 0;
-        ++n_tries;
-        if (g_font_info[0].loaded && g_font_info[0].name) {
-            try_names[n_tries] = g_font_info[0].name;
-            try_sizes[n_tries] = g_font_info[0].size;
-            ++n_tries;
-        }
-
-        while (1) {
-            if (i >= n_tries) {
-                quit_fmt("No usable status bar font for "
-                    "window %u; configured to use '%s'",
-                    window->index, try_names[0]);
-            }
-            window->status_bar.font =
-                make_font(window, try_names[i], try_sizes[i]);
-            if (window->status_bar.font) {
-                if (i > 0) {
-                    plog_fmt("Font '%s' unusable; "
-                        "substituting '%s'",
-                        try_names[0], try_names[i]);
-                    if (window->config) {
-                        string_free(window->config->font_name);
-                        window->config->font_name =
-                            string_make(try_names[i]);
-                    }
-                }
-                break;
-            }
-            ++i;
-        }
+    c = sdlpui_get_simple_menu_next_unused(window->status_bar,
+        SDLPUI_MFLG_END_GRAVITY);
+    window->move_button = c;
+    sdlpui_create_menu_toggle(c, "Move", SDLPUI_HOR_CENTER,
+        handle_button_movesize, 0, false, false);
+    c = sdlpui_get_simple_menu_next_unused(window->status_bar,
+        SDLPUI_MFLG_END_GRAVITY);
+    window->size_button = c;
+    sdlpui_create_menu_toggle(c, "Size", SDLPUI_HOR_CENTER,
+        handle_button_movesize, 1, false, false);
+    sdlpui_complete_simple_menu(window->status_bar, window);
+    if (window->status_bar->ftb->query_minimum_size) {
+        (*window->status_bar->ftb->query_minimum_size)(
+            window->status_bar, window, &w, &h);
     } else {
-        quit_fmt("font '%s' already loaded in status bar in window %u",
-                window->status_bar.font->name, window->index);
+        (*window->status_bar->ftb->query_natural_size)(
+            window->status_bar, window, &w, &h);
     }
-
-    adjust_status_bar_geometry(window);
-
-    window->status_bar.texture = make_subwindow_texture(window,
-            window->status_bar.full_rect.w, window->status_bar.full_rect.h);
-
-    /* let's try renderer */
-    if (SDL_SetRenderDrawColor(window->renderer,
-                window->status_bar.color.r, window->status_bar.color.g,
-                window->status_bar.color.b, window->status_bar.color.a) != 0) {
-        quit_fmt("cannot set render color for status bar in window %u: %s",
-                window->index, SDL_GetError());
+    if (w > window->full_rect.w) {
+        quit("Window is too narrow for menu bar");
+    } else if (w < window->full_rect.w) {
+        if (window->status_bar->ftb->resize) {
+            (*window->status_bar->ftb->resize)(window->status_bar,
+                window, window->full_rect.w, h);
+        } else {
+            window->status_bar->rect.w = window->full_rect.w;
+            window->status_bar->rect.h = h;
+        }
     }
-    /* well, renderer seems to work */
-    if (SDL_SetRenderTarget(window->renderer, window->status_bar.texture) != 0) {
-        quit_fmt("cannot set status bar texture as target in window %u: %s",
-                window->index, SDL_GetError());
-    }
-    /* does it render? */
-    if (SDL_RenderClear(window->renderer) != 0) {
-        quit_fmt("cannot clear status bar texture in window %u: %s",
-                window->index, SDL_GetError());
-    }
-
-    /* well, it probably works */
-    window->status_bar.window = window;
+    /*
+     * Anchored to the top left corner of the window and not dismissed
+     * when submenus are popped down.
+     */
+    window->status_bar->rect.x = 0;
+    window->status_bar->rect.y = 0;
+    window->status_bar->pinned = true;
+    sdlpui_popup_dialog(window->status_bar, window, false);
 }
 
-static void fit_subwindow_in_window(const struct window *window,
+static void reload_status_bar(struct sdlpui_window *window)
+{
+    close_status_bar_menu(window);
+    load_status_bar(window);
+}
+
+static void fit_subwindow_in_window(const struct sdlpui_window *window,
         struct subwindow *subwindow)
 {
     fit_rect_in_rect_by_xy(&subwindow->full_rect, &window->inner_rect);
@@ -5119,7 +5062,7 @@ static void fit_subwindow_in_window(const struct window *window,
     }
 }
 
-static void resize_window(struct window *window, int w, int h)
+static void resize_window(struct sdlpui_window *window, int w, int h)
 {
     if (window->full_rect.w == w
             && window->full_rect.h == h)
@@ -5141,12 +5084,12 @@ static void resize_window(struct window *window, int w, int h)
         }
     }
 
-    reload_status_bar(&window->status_bar);
+    reload_status_bar(window);
 
     redraw_window(window);
 }
 
-static void adjust_window_geometry(struct window *window)
+static void adjust_window_geometry(struct sdlpui_window *window)
 {
     window->inner_rect.x = 0;
     window->inner_rect.y = 0;
@@ -5154,7 +5097,7 @@ static void adjust_window_geometry(struct window *window)
     window->inner_rect.h = window->full_rect.h;
 
     resize_rect(&window->inner_rect,
-            0, window->status_bar.full_rect.h, 0, 0);
+            0, window->status_bar->rect.h, 0, 0);
 
     if (window->inner_rect.w <= 0
             || window->inner_rect.h <= 0) {
@@ -5163,7 +5106,7 @@ static void adjust_window_geometry(struct window *window)
     }
 }
 
-static void set_window_delay(struct window *window)
+static void set_window_delay(struct sdlpui_window *window)
 {
     assert(window->window != NULL);
 
@@ -5184,12 +5127,56 @@ static void set_window_delay(struct window *window)
 }
 
 /* initialize miscellaneous things in window */
-static void load_window(struct window *window)
+static void load_window(struct sdlpui_window *window)
 {
+    if (window->dialog_font == NULL) {
+        const char *try_names[3];
+        int try_sizes[3];
+        int n_tries = 0, i = 0;
+
+        if (window->config && window->config->font_name) {
+            try_names[n_tries] = window->config->font_name;
+            try_sizes[n_tries] = window->config->font_size;
+            ++n_tries;
+        }
+        try_names[n_tries] = DEFAULT_DIALOG_FONT;
+        try_sizes[n_tries] = 0;
+        ++n_tries;
+        if (window->app->font_count > 0 && window->app->fonts[0].name) {
+            try_names[n_tries] = window->app->fonts[0].name;
+            try_sizes[n_tries] = window->app->fonts[0].size;
+            ++n_tries;
+        }
+
+        while (1) {
+            if (i >= n_tries) {
+                quit_fmt("No usable status bar font for "
+                    "window %u; configured to use '%s'",
+                    window->index, try_names[0]);
+            }
+            window->dialog_font =
+                make_font(window, try_names[i], try_sizes[i]);
+            if (window->dialog_font) {
+                if (i > 0) {
+                    plog_fmt("Font '%s' unusable; "
+                        "substituting '%s'",
+                        try_names[0], try_names[i]);
+                    if (window->config) {
+                        string_free(window->config->font_name);
+                        window->config->font_name =
+                            string_make(try_names[i]);
+                    }
+                }
+                break;
+            }
+            ++i;
+        }
+    }
+    window->stipple = sdlpui_compute_stipple(window->renderer);
     load_status_bar(window);
+    window->infod = NULL;
+    window->shorte = NULL;
     adjust_window_geometry(window);
-    make_button_bank(&window->status_bar.button_bank);
-    make_default_status_buttons(&window->status_bar);
     set_window_delay(window);
     if (window->wallpaper.mode != WALLPAPER_DONT_SHOW) {
         if (window->config == NULL) {
@@ -5198,7 +5185,6 @@ static void load_window(struct window *window)
             load_wallpaper(window, window->config->wallpaper_path);
         }
     }
-    load_stipple(window);
     load_default_window_icon(window);
     if (window->graphics.id != GRAPHICS_NONE) {
         load_graphics(window, get_graphics_mode(window->graphics.id, true));
@@ -5210,7 +5196,7 @@ static void load_window(struct window *window)
     window->loaded = true;
 }
 
-static bool choose_pixelformat(struct window *window,
+static bool choose_pixelformat(struct sdlpui_window *window,
         const struct SDL_RendererInfo *info)
 {
 #define TRY_SET_WINDOW_PIXELFORMAT(format) \
@@ -5229,7 +5215,7 @@ static bool choose_pixelformat(struct window *window,
     return false;
 }
 
-static void start_window(struct window *window)
+static void start_window(struct sdlpui_window *window)
 {
     assert(!window->loaded);
 
@@ -5284,12 +5270,13 @@ static void start_window(struct window *window)
     window->id = SDL_GetWindowID(window->window);
 }
 
-static void wipe_window_aux_config(struct window *window)
+static void wipe_window_aux_config(struct sdlpui_window *window)
 {
     window->config = mem_zalloc(sizeof(*window->config));
     assert(window->config != NULL);
 
-    const struct window *main_window = get_window_direct(MAIN_WINDOW);
+    const struct sdlpui_window *main_window =
+        get_window_direct(window->app, MAIN_WINDOW);
     assert(main_window != NULL);
 
     SDL_RendererInfo rinfo;
@@ -5305,7 +5292,7 @@ static void wipe_window_aux_config(struct window *window)
         char path[4096];
         path_build(path, sizeof(path), DEFAULT_WALLPAPER_DIR, DEFAULT_WALLPAPER);
         window->config->wallpaper_path = string_make(path);
-        window->config->font_name = string_make(DEFAULT_STATUS_BAR_FONT);
+        window->config->font_name = string_make(DEFAULT_DIALOG_FONT);
     } else {
         window->config->wallpaper_path = string_make(main_window->config->wallpaper_path);
         window->config->font_name = string_make(main_window->config->font_name);
@@ -5331,11 +5318,14 @@ static void wipe_window_aux_config(struct window *window)
 }
 
 /* initialize window with suitable hardcoded defaults */
-static void wipe_window(struct window *window, int display)
+static void wipe_window(struct sdlpui_window *window, int display)
 {
+    struct my_app *app = window->app;
     unsigned index = window->index;
     memset(window, 0, sizeof(*window));
+    window->app = app;
     window->index = index;
+    window->outlined_subwindow = (unsigned)-1;
 
     for (size_t j = 0; j < N_ELEMENTS(window->subwindows); j++) {
         window->subwindows[j] = NULL;
@@ -5352,21 +5342,13 @@ static void wipe_window(struct window *window, int display)
     window->full_rect.w = mode.w;
     window->full_rect.h = mode.h;
 
-    window->color = g_colors[DEFAULT_WINDOW_BG_COLOR];
+    window->color = window->app->colors[DEFAULT_WINDOW_BG_COLOR];
     window->alpha = DEFAULT_ALPHA_FULL;
-
-    window->status_bar.font = NULL;
 
     window->wallpaper.texture = NULL;
     window->wallpaper.mode = WALLPAPER_TILED;
 
     window->stipple.texture = NULL;
-
-    window->status_bar.font = NULL;
-    window->status_bar.color = g_colors[DEFAULT_STATUS_BAR_BG_COLOR];
-    window->status_bar.button_bank.buttons = NULL;
-    window->status_bar.menu_panel = NULL;
-    window->status_bar.in_menu = false;
 
     window->graphics.texture = NULL;
     window->graphics.id = GRAPHICS_NONE;
@@ -5398,7 +5380,7 @@ static void dump_subwindow(const struct subwindow *subwindow, ang_file *config)
     file_put(config, "\n");
 }
 
-static void dump_window(const struct window *window, ang_file *config)
+static void dump_window(const struct sdlpui_window *window, ang_file *config)
 {
 #define DUMP_WINDOW(sym, fmt, ...) \
     file_putf(config, "window-" sym ":%u:" fmt "\n", window->index, __VA_ARGS__)
@@ -5430,7 +5412,7 @@ static void dump_window(const struct window *window, ang_file *config)
             window->wallpaper.mode == WALLPAPER_SCALED    ? "scaled"   :
             "ERROR");
     DUMP_WINDOW("status-bar-font", "%d:%s",
-            window->status_bar.font->size, window->status_bar.font->name);
+            window->dialog_font->size, window->dialog_font->name);
 
     DUMP_WINDOW("graphics-id", "%d", window->graphics.id);
     DUMP_WINDOW("tile-scale", "width:%d", tile_width);
@@ -5446,7 +5428,7 @@ static void dump_window(const struct window *window, ang_file *config)
     }
 }
 
-static void detach_subwindow_from_window(struct window *window,
+static void detach_subwindow_from_window(struct sdlpui_window *window,
         struct subwindow *subwindow)
 {
     assert(subwindow->window == window);
@@ -5458,9 +5440,28 @@ static void detach_subwindow_from_window(struct window *window,
     assert(i < N_ELEMENTS(window->subwindows));
 
     window->subwindows[i] = NULL;
+    /* Also update the state of the menu bar. */
+    if (window->status_bar) {
+        int cidx = subwindow->index
+            + ((window->index == MAIN_WINDOW) ? 1 : 0);
+        struct sdlpui_simple_menu *sm;
+        struct sdlpui_menu_button *mb;
+
+        assert(window->status_bar->type_code
+            == SDLPUI_DIALOG_SIMPLE_MENU);
+        sm = (struct sdlpui_simple_menu*)window->status_bar->priv;
+        assert(cidx < sm->number);
+        assert(sm->controls[cidx].type_code
+            == SDLPUI_CTRL_MENU_BUTTON);
+        mb = (struct sdlpui_menu_button*)sm->controls[cidx].priv;
+        assert(mb->subtype_code == SDLPUI_MB_TOGGLE);
+        mb->v.toggled = false;
+        window->status_bar->dirty = true;
+        window->dirty = true;
+    }
 }
 
-static void attach_subwindow_to_window(struct window *window,
+static void attach_subwindow_to_window(struct sdlpui_window *window,
         struct subwindow *subwindow)
 {
     assert(subwindow->window == window);
@@ -5474,9 +5475,10 @@ static void attach_subwindow_to_window(struct window *window,
     window->subwindows[i] = subwindow;
 }
 
-static struct subwindow *make_subwindow(struct window *window, unsigned index)
+static struct subwindow *make_subwindow(struct sdlpui_window *window,
+        unsigned index)
 {
-    struct subwindow *subwindow = get_new_subwindow(index);
+    struct subwindow *subwindow = get_new_subwindow(window->app, index);
     assert(subwindow != NULL);
 
     load_subwindow(window, subwindow);
@@ -5486,9 +5488,10 @@ static struct subwindow *make_subwindow(struct window *window, unsigned index)
     return subwindow;
 }
 
-static struct subwindow *transfer_subwindow(struct window *window, unsigned index)
+static struct subwindow *transfer_subwindow(struct sdlpui_window *window,
+        unsigned index)
 {
-    struct subwindow *subwindow = get_subwindow_direct(index);
+    struct subwindow *subwindow = get_subwindow_direct(window->app, index);
     assert(subwindow != NULL);
     assert(subwindow->inited);
     assert(subwindow->loaded);
@@ -5522,7 +5525,8 @@ static struct subwindow *transfer_subwindow(struct window *window, unsigned inde
     return subwindow;
 }
 
-static void load_subwindow(struct window *window, struct subwindow *subwindow)
+static void load_subwindow(struct sdlpui_window *window,
+        struct subwindow *subwindow)
 {
     assert(window->loaded);
     assert(!subwindow->loaded);
@@ -5540,9 +5544,9 @@ static void load_subwindow(struct window *window, struct subwindow *subwindow)
         try_names[n_tries] = DEFAULT_FONT;
         try_sizes[n_tries] = 0;
         ++n_tries;
-        if (g_font_info[0].loaded && g_font_info[0].name) {
-            try_names[n_tries] = g_font_info[0].name;
-            try_sizes[n_tries] = g_font_info[0].size;
+        if (window->app->font_count > 0 && window->app->fonts[0].name) {
+            try_names[n_tries] = window->app->fonts[0].name;
+            try_sizes[n_tries] = window->app->fonts[0].size;
             ++n_tries;
         }
 
@@ -5688,8 +5692,10 @@ static void load_term(struct subwindow *subwindow)
 /* initialize subwindow with suitable hardcoded defaults */
 static bool wipe_subwindow(struct subwindow *subwindow)
 {
+    struct my_app *app = subwindow->app;
     unsigned index = subwindow->index;
     memset(subwindow, 0, sizeof(*subwindow));
+    subwindow->app = app;
     subwindow->index = index;
 
     /* XXX 80x24 is essential for main */
@@ -5702,8 +5708,8 @@ static bool wipe_subwindow(struct subwindow *subwindow)
     subwindow->cols = MIN_COLS_MAIN;
     subwindow->rows = MIN_ROWS_MAIN;
 
-    subwindow->color = g_colors[DEFAULT_SUBWINDOW_BG_COLOR];
-    subwindow->borders.color = g_colors[DEFAULT_SUBWINDOW_BORDER_COLOR];
+    subwindow->color = subwindow->app->colors[DEFAULT_SUBWINDOW_BG_COLOR];
+    subwindow->borders.color = subwindow->app->colors[DEFAULT_SUBWINDOW_BORDER_COLOR];
     subwindow->borders.visible = true;
 
     subwindow->texture = NULL;
@@ -5718,16 +5724,6 @@ static bool wipe_subwindow(struct subwindow *subwindow)
     subwindow->visible = true;
 
     return true;
-}
-
-static void get_string_metrics(struct font *font, const char *str, int *w, int *h)
-{
-    assert(font != NULL);
-    assert(font->ttf.handle != NULL);
-
-    if (TTF_SizeUTF8(font->ttf.handle, str, w, h) != 0) {
-        quit_fmt("cannot get string metrics for string '%s': %s", str, TTF_GetError());
-    }
 }
 
 static int sort_cb_font_info(const void *infoa, const void *infob)
@@ -5823,45 +5819,6 @@ static bool is_font_file(const char *path)
     return is_font;
 }
 
-static void free_menu_panel(struct menu_panel *menu_panel)
-{
-    while (menu_panel) {
-        struct menu_panel *next = menu_panel->next;
-        free_button_bank(&menu_panel->button_bank);
-        mem_free(menu_panel);
-        menu_panel = next;
-    }
-}
-
-static void free_button_bank(struct button_bank *button_bank)
-{
-    for (size_t i = 0; i < button_bank->number; i++) {
-        mem_free(button_bank->buttons[i].caption);
-    }
-    mem_free(button_bank->buttons);
-    button_bank->buttons = NULL;
-    button_bank->number = 0;
-    button_bank->size = 0;
-}
-
-static void free_status_bar(struct status_bar *status_bar)
-{
-    if (status_bar->menu_panel != NULL) {
-        free_menu_panel(status_bar->menu_panel);
-        status_bar->menu_panel = NULL;
-    }
-    if (status_bar->button_bank.buttons != NULL) {
-        free_button_bank(&status_bar->button_bank);
-    }
-    if (status_bar->texture != NULL) {
-        SDL_DestroyTexture(status_bar->texture);
-        status_bar->texture = NULL;
-    }
-
-    free_font(status_bar->font);
-    status_bar->font = NULL;
-}
-
 static void free_font_info(struct font_info *font_info)
 {
     if (font_info->name != NULL) {
@@ -5872,7 +5829,6 @@ static void free_font_info(struct font_info *font_info)
         mem_free(font_info->path);
         font_info->path = NULL;
     }
-    font_info->loaded = false;
 }
 
 static void free_window_config(struct window_config *config)
@@ -5929,9 +5885,21 @@ static void free_subwindow(struct subwindow *subwindow)
     subwindow->inited = false;
 }
 
-static void free_window(struct window *window)
+static void free_window(struct sdlpui_window *window)
 {
     assert(window->loaded);
+
+    while (window->d_head) {
+        sdlpui_popdown_dialog(window->d_head, window, false);
+    }
+    window->d_tail = NULL;
+    window->d_mouse = NULL;
+    window->d_key = NULL;
+    window->status_bar = NULL;
+    window->move_button = NULL;
+    window->size_button = NULL;
+    window->infod = NULL;
+    window->shorte = NULL;
 
     for (size_t i = 0; i < N_ELEMENTS(window->subwindows); i++) {
         struct subwindow *subwindow = window->subwindows[i];
@@ -5940,8 +5908,6 @@ static void free_window(struct window *window)
             window->subwindows[i] = NULL;
         }
     }
-
-    free_status_bar(&window->status_bar);
 
     if (window->wallpaper.texture != NULL) {
         SDL_DestroyTexture(window->wallpaper.texture);
@@ -5952,6 +5918,9 @@ static void free_window(struct window *window)
         SDL_DestroyTexture(window->stipple.texture);
         window->stipple.texture = NULL;
     }
+
+    free_font(window->dialog_font);
+    window->dialog_font = NULL;
 
     free_graphics(&window->graphics);
 
@@ -5974,90 +5943,92 @@ static void free_window(struct window *window)
     window->inited = false;
 }
 
-static void init_colors(void)
+static void init_colors(struct my_app *a)
 {
-    assert(N_ELEMENTS(g_colors) == N_ELEMENTS(angband_color_table));
+    assert(N_ELEMENTS(a->colors) == N_ELEMENTS(angband_color_table));
     size_t i;
 
-    for (i = 0; i < N_ELEMENTS(g_colors); i++) {
-        g_colors[i].r = angband_color_table[i][1];
-        g_colors[i].g = angband_color_table[i][2];
-        g_colors[i].b = angband_color_table[i][3];
-        g_colors[i].a = DEFAULT_ALPHA_FULL;
+    for (i = 0; i < N_ELEMENTS(a->colors); i++) {
+        a->colors[i].r = angband_color_table[i][1];
+        a->colors[i].g = angband_color_table[i][2];
+        a->colors[i].b = angband_color_table[i][3];
+        a->colors[i].a = DEFAULT_ALPHA_FULL;
     }
-    for (i = 0; i < N_ELEMENTS(g_windows); i++) {
-        g_windows[i].color = g_colors[DEFAULT_WINDOW_BG_COLOR];
+    for (i = 0; i < N_ELEMENTS(a->windows); i++) {
+        a->windows[i].color = a->colors[DEFAULT_WINDOW_BG_COLOR];
     }
-    for (i = 0; i < N_ELEMENTS(g_subwindows); i++) {
+    for (i = 0; i < N_ELEMENTS(a->subwindows); i++) {
         /* Retain whatever customized alpha the subwindow has. */
-        g_subwindows[i].color.r =
-            g_colors[DEFAULT_SUBWINDOW_BG_COLOR].r;
-        g_subwindows[i].color.g =
-            g_colors[DEFAULT_SUBWINDOW_BG_COLOR].g;
-        g_subwindows[i].color.b =
-            g_colors[DEFAULT_SUBWINDOW_BG_COLOR].b;
+        a->subwindows[i].color.r =
+            a->colors[DEFAULT_SUBWINDOW_BG_COLOR].r;
+        a->subwindows[i].color.g =
+            a->colors[DEFAULT_SUBWINDOW_BG_COLOR].g;
+        a->subwindows[i].color.b =
+            a->colors[DEFAULT_SUBWINDOW_BG_COLOR].b;
     }
 }
 
-static void init_font_info(const char *directory)
+static void init_font_info(struct my_app *a, const char *directory)
 {
-    /* well maybe it will get ability to be reinitialized at some point */
-    for (size_t i = 0; i < N_ELEMENTS(g_font_info); i++) {
-        g_font_info[i].name = NULL;
-        g_font_info[i].path = NULL;
-        g_font_info[i].loaded = false;
-    }
+    char name[1024];
+    ang_dir *dir;
 
-    ang_dir *dir = my_dopen(directory);
+    a->font_count = 0;
+    a->font_alloc = 0;
+    a->fonts = NULL;
+
+    dir = my_dopen(directory);
     if (!dir) {
         quit_fmt("Font directory '%s' is unreadable", directory);
     }
 
-    char name[1024];
-    char path[4096];
+    while (my_dread(dir, name, sizeof(name))) {
+        char path[4096];
 
-    size_t i = 0;
-    while (i < N_ELEMENTS(g_font_info) && my_dread(dir, name, sizeof(name))) {
         path_build(path, sizeof(path), directory, name);
 
         if (is_font_file(path)) {
-            g_font_info[i].name = string_make(name);
-            g_font_info[i].path = string_make(path);
-            g_font_info[i].loaded = true;
-            if (suffix_i(path, ".fon")) {
-                g_font_info[i].type = FONT_TYPE_RASTER;
-                g_font_info[i].size = 0;
-            } else {
-                g_font_info[i].type = FONT_TYPE_VECTOR;
-                g_font_info[i].size = DEFAULT_VECTOR_FONT_SIZE;
+            if (a->font_count >= a->font_alloc) {
+                if (a->font_count > 1024) {
+                    break;
+                }
+                a->font_alloc = (a->font_alloc)
+                    ? 2 * a->font_alloc : 32;
+                a->fonts = mem_realloc(a->fonts,
+                    a->font_alloc * sizeof(*a->fonts));
             }
-            i++;
+            a->fonts[a->font_count].name = string_make(name);
+            a->fonts[a->font_count].path = string_make(path);
+            if (suffix_i(path, ".fon")) {
+                a->fonts[a->font_count].type = FONT_TYPE_RASTER;
+                a->fonts[a->font_count].size = 0;
+            } else {
+                a->fonts[a->font_count].type = FONT_TYPE_VECTOR;
+                a->fonts[a->font_count].size =
+                    DEFAULT_VECTOR_FONT_SIZE;
+            }
+            ++a->font_count;
         }
     }
-    if (!i) {
+    if (!a->font_count) {
         quit_fmt("No usable fonts found in '%s'", directory);
     }
 
-    sort(g_font_info, i, sizeof(g_font_info[0]), sort_cb_font_info);
+    sort(a->fonts, a->font_count, sizeof(a->fonts[0]), sort_cb_font_info);
 
-    for (size_t j = 0; j < i; j++) {
-        g_font_info[j].index = j;
-    }
-
-    /* Check font_page */
-    if (i > MAX_BUTTONS) {
-        font_page = true;
+    for (int i = 0; i < a->font_count; ++i) {
+        a->fonts[i].index = i;
     }
 
     my_dclose(dir);
 }
 
-static void create_defaults(void)
+static void create_defaults(struct my_app *a)
 {
-    struct window *window = get_new_window(MAIN_WINDOW);
+    struct sdlpui_window *window = get_new_window(a, MAIN_WINDOW);
     assert(window != NULL);
 
-    struct subwindow *subwindow = get_new_subwindow(MAIN_SUBWINDOW);
+    struct subwindow *subwindow = get_new_subwindow(a, MAIN_SUBWINDOW);
     assert(subwindow != NULL);
 
     assert(MAIN_SUBWINDOW < N_ELEMENTS(window->subwindows));
@@ -6067,6 +6038,7 @@ static void create_defaults(void)
 static void quit_systems(void)
 {
     SDL_StopTextInput();
+    sdlpui_quit();
     TTF_Quit();
     IMG_Quit();
     SDL_Quit();
@@ -6078,11 +6050,11 @@ static void quit_hook(const char *s)
      * If at least the main window was successfully set up, remember the
      * configuration.
      */
-    if (g_windows[0].loaded) {
-        dump_config_file();
+    if (g_app.windows[0].loaded) {
+        dump_config_file(&g_app);
     }
 
-    free_globals();
+    free_globals(&g_app);
     quit_systems();
 
     /* Free resources */
@@ -6101,6 +6073,9 @@ static void quit_hook(const char *s)
 
 static void init_systems(void)
 {
+#if defined(SDLPUI_TRACE_EVENTS) || defined(SDLPUI_TRACE_RENDER)
+    SDL_LogSetAllPriority(SDL_LOG_PRIORITY_VERBOSE);
+#endif
     if (SDL_Init(INIT_SDL_FLAGS) != 0) {
         quit_fmt("SDL_Init: %s", SDL_GetError());
     }
@@ -6111,6 +6086,11 @@ static void init_systems(void)
     if (TTF_Init() != 0) {
         quit_fmt("TTF_Init: %s", TTF_GetError());
     }
+    if (sdlpui_init()) {
+        quit("sdlpui_init() failed");
+    }
+    SHORTCUT_EDITOR_CODE = sdlpui_register_code("ANGBAND_SHORTCUT_EDITOR");
+    SDL_assert(SHORTCUT_EDITOR_CODE);
 
     /* On (some?) Macs the touchpad sends both mouse events and touch events;
      * the latter interfere badly with the working of the status bar */
@@ -6151,74 +6131,76 @@ errr init_sdl2(void)
     quit_aux = quit_hook;
 
     init_systems();
-    init_globals();
 
     if (!init_graphics_modes()) {
         quit("Graphics list load failed");
     }
 
-    if (!read_config_file()) {
-        create_defaults();
+    init_globals(&g_app);
+    if (!read_config_file(&g_app)) {
+        create_defaults(&g_app);
     }
 
-    start_windows();
-    load_terms();
+    start_windows(&g_app);
+    load_terms(&g_app);
 
     return 0;
 }
 
-/* the string ANGBAND_DIR_USER is freed before calling quit_hook(),
- * so we need to save the path to config file here */
-static char g_config_file[4096];
-
-static void init_globals(void)
+static void init_globals(struct my_app *a)
 {
-    path_build(g_config_file, sizeof(g_config_file),
+    path_build(a->config_file, sizeof(a->config_file),
             DEFAULT_CONFIG_FILE_DIR, DEFAULT_CONFIG_FILE);
 
-    for (size_t i = 0; i < N_ELEMENTS(g_subwindows); i++) {
-        g_subwindows[i].index = i;
+    for (size_t i = 0; i < N_ELEMENTS(a->subwindows); i++) {
+        a->subwindows[i].index = i;
+        a->subwindows[i].app = a;
     }
-    for (size_t i = 0; i < N_ELEMENTS(g_windows); i++) {
-        g_windows[i].index = i;
+    for (size_t i = 0; i < N_ELEMENTS(a->windows); i++) {
+        a->windows[i].index = i;
+        a->windows[i].app = a;
+        a->menu_shortcuts[i] = KEYPRESS_NULL;
     }
 
-    init_font_info(ANGBAND_DIR_FONTS);
-    init_colors();
+    init_font_info(a, ANGBAND_DIR_FONTS);
+    init_colors(a);
+
+    a->w_mouse = NULL;
+    a->w_key = NULL;
+    a->kp_as_mod = true;
 }
 
-static bool is_subwindow_loaded(unsigned index)
+static bool is_subwindow_loaded(struct my_app *a, unsigned index)
 {
-    const struct subwindow *subwindow = get_subwindow_direct(index);
+    const struct subwindow *subwindow = get_subwindow_direct(a, index);
     assert(subwindow != NULL);
 
     return subwindow->loaded;
 }
 
-static struct subwindow *get_subwindow_direct(unsigned index)
+static struct subwindow *get_subwindow_direct(struct my_app *a, unsigned index)
 {
     size_t i;
-    if (index < N_ELEMENTS(g_subwindows)
-            && g_subwindows[index].index == index)
-    {
+    if (index < N_ELEMENTS(a->subwindows)
+            && a->subwindows[index].index == index) {
         i = index;
     } else {
-        for (i = 0; i < N_ELEMENTS(g_subwindows); i++) {
-            if (g_subwindows[i].index == index) {
+        for (i = 0; i < N_ELEMENTS(a->subwindows); i++) {
+            if (a->subwindows[i].index == index) {
                 break;
             }
         }
-        if (i == N_ELEMENTS(g_subwindows)) {
+        if (i == N_ELEMENTS(a->subwindows)) {
             return NULL;
         }
     }
 
-    return &g_subwindows[i];
+    return &a->subwindows[i];
 }
 
-static struct subwindow *get_new_subwindow(unsigned index)
+static struct subwindow *get_new_subwindow(struct my_app *a, unsigned index)
 {
-    struct subwindow *subwindow = get_subwindow_direct(index);
+    struct subwindow *subwindow = get_subwindow_direct(a, index);
     assert(subwindow != NULL);
     assert(!subwindow->inited);
     assert(!subwindow->loaded);
@@ -6231,12 +6213,12 @@ static struct subwindow *get_new_subwindow(unsigned index)
     return subwindow;
 }
 
-static struct window *get_new_window(unsigned index)
+static struct sdlpui_window *get_new_window(struct my_app *a, unsigned index)
 {
-    assert(index < N_ELEMENTS(g_windows));
-    assert(g_windows[index].index == index);
+    assert(index < N_ELEMENTS(a->windows));
+    assert(a->windows[index].index == index);
 
-    struct window *window = &g_windows[index];
+    struct sdlpui_window *window = &a->windows[index];
     assert(!window->inited);
     assert(!window->loaded);
 
@@ -6245,64 +6227,68 @@ static struct window *get_new_window(unsigned index)
     return window;
 }
 
-static struct window *get_window_direct(unsigned index)
+static struct sdlpui_window *get_window_direct(struct my_app *a, unsigned index)
 {
-    assert(index < N_ELEMENTS(g_windows));
+    assert(index < N_ELEMENTS(a->windows));
 
-    if (g_windows[index].loaded) {
-        assert(g_windows[index].index == index);
-        return &g_windows[index];
+    if (a->windows[index].loaded) {
+        assert(a->windows[index].index == index);
+        return &a->windows[index];
     }
 
     return NULL;
 }
 
-static struct window *get_window_by_id(Uint32 id)
+static struct sdlpui_window *get_window_by_id(struct my_app *a, Uint32 id)
 {
-    for (size_t i = 0; i < N_ELEMENTS(g_windows); i++) {
-        if (g_windows[i].loaded && g_windows[i].id == id) {
-            return &g_windows[i];
+    for (size_t i = 0; i < N_ELEMENTS(a->windows); i++) {
+        if (a->windows[i].loaded && a->windows[i].id == id) {
+            return &a->windows[i];
         }
     }
     
     return NULL;
 }
 
-static void free_globals(void)
+static void free_globals(struct my_app *a)
 {
-    for (size_t i = 0; i < N_ELEMENTS(g_font_info); i++) {
-        free_font_info(&g_font_info[i]);
+    for (int i = 0; i < a->font_count; i++) {
+        free_font_info(&a->fonts[i]);
     }
-    for (size_t i = 0; i < N_ELEMENTS(g_windows); i++) {
-        if (g_windows[i].loaded) {
-            free_window(&g_windows[i]);
+    mem_free(a->fonts);
+    a->fonts = NULL;
+    a->font_count = 0;
+    a->font_alloc = 0;
+    for (size_t i = 0; i < N_ELEMENTS(a->windows); i++) {
+        if (a->windows[i].loaded) {
+            free_window(&a->windows[i]);
         }
     }
-    for (size_t i = 0; i < N_ELEMENTS(g_subwindows); i++) {
-        assert(!g_subwindows[i].inited);
-        assert(!g_subwindows[i].loaded);
-        assert(!g_subwindows[i].linked);
+    for (size_t i = 0; i < N_ELEMENTS(a->subwindows); i++) {
+        assert(!a->subwindows[i].inited);
+        assert(!a->subwindows[i].loaded);
+        assert(!a->subwindows[i].linked);
     }
 }
 
-static void start_windows(void)
+static void start_windows(struct my_app *a)
 {
-    for (size_t i = N_ELEMENTS(g_windows); i > 0; i--) {
-        if (g_windows[i - 1].inited) {
-            start_window(&g_windows[i - 1]);
+    for (size_t i = N_ELEMENTS(a->windows); i > 0; i--) {
+        if (a->windows[i - 1].inited) {
+            start_window(&a->windows[i - 1]);
         }
     }
 }
 
-static void load_terms(void)
+static void load_terms(struct my_app *a)
 {
-    for (size_t i = 0; i < N_ELEMENTS(g_subwindows); i++) {
-        if (g_subwindows[i].loaded) {
+    for (size_t i = 0; i < N_ELEMENTS(a->subwindows); i++) {
+        if (a->subwindows[i].loaded) {
             /* Hack -- don't load chat window (term_chat) if visible = false */
-            if (g_subwindows[i].index == CHAT_SUBWINDOW && !g_subwindows[i].visible) {
+            if (a->subwindows[i].index == CHAT_SUBWINDOW && !a->subwindows[i].visible) {
                 continue;
             }
-            load_term(&g_subwindows[i]);
+            load_term(&a->subwindows[i]);
         }
     }
 
@@ -6311,18 +6297,31 @@ static void load_terms(void)
 
 /* Config file stuff */
 
-static void dump_config_file(void)
+static void dump_config_file(const struct my_app *a)
 {
-    ang_file *config = file_open(g_config_file, MODE_WRITE, FTYPE_TEXT);
+    ang_file *config = file_open(a->config_file, MODE_WRITE, FTYPE_TEXT);
 
     assert(config != NULL);
 
-    for (size_t i = 0; i < N_ELEMENTS(g_windows); i++) {
-        if (g_windows[i].loaded) {
-            dump_window(&g_windows[i], config);
+    for (size_t i = 0; i < N_ELEMENTS(a->windows); i++) {
+        if (a->windows[i].loaded) {
+            dump_window(&a->windows[i], config);
         }
     }
-    file_putf(config, "kp-as-modifier:%d\n", (g_kp_as_mod) ? 1 : 0);
+    for (size_t i = 0; i < N_ELEMENTS(a->menu_shortcuts); i++) {
+        char keypress[1024];
+
+        if (a->menu_shortcuts[i].type == EVT_KBRD
+                && a->menu_shortcuts[i].code) {
+            keypress_to_text(keypress, sizeof(keypress),
+                a->menu_shortcuts + i, false);
+        } else {
+            my_strcpy(keypress, "None", sizeof(keypress));
+        }
+        file_putf(config, "menu-shortcut:%u:%s\n", (unsigned int)i,
+            keypress);
+    }
+    file_putf(config, "kp-as-modifier:%d\n", (a->kp_as_mod) ? 1 : 0);
     file_putf(config, "map-modifier:%d\n", (view_map_hook_mod) ? 1 : 0);
     file_putf(config, "sound-volume:%d\n", sound_volume);
     file_putf(config, "music-volume:%d\n", music_volume);
@@ -6330,34 +6329,30 @@ static void dump_config_file(void)
     file_close(config);
 }
 
-/* XXX more bad style :) */
-#define GET_WINDOW_FROM_INDEX \
-    if (parser_getuint(parser, "index") >= N_ELEMENTS(g_windows)) { \
-        return PARSE_ERROR_OUT_OF_BOUNDS; \
-    } \
-    struct window *window = &g_windows[parser_getuint(parser, "index")]; \
+static struct sdlpui_window *get_window_from_parser(struct parser *parser)
+{
+    struct my_app *a = parser_priv(parser);
+    unsigned int ind = parser_getuint(parser, "index");
 
-#define WINDOW_INIT_OK \
-    if (!window->inited) { \
-        return PARSE_ERROR_MISSING_RECORD_HEADER; \
-    }
+    return (ind >= N_ELEMENTS(a->windows)) ? NULL : &a->windows[ind];
+}
 
-#define GET_SUBWINDOW_FROM_INDEX \
-    if (parser_getuint(parser, "index") >= N_ELEMENTS(g_subwindows)) { \
-        return PARSE_ERROR_OUT_OF_BOUNDS; \
-    } \
-    struct subwindow *subwindow = &g_subwindows[parser_getuint(parser, "index")]; \
+static struct subwindow *get_subwindow_from_parser(struct parser *parser)
+{
+    struct my_app *a = parser_priv(parser);
+    unsigned int ind = parser_getuint(parser, "index");
 
-#define SUBWINDOW_INIT_OK \
-    if (!subwindow->inited) { \
-        return PARSE_ERROR_MISSING_RECORD_HEADER; \
-    }
+    return (ind >= N_ELEMENTS(a->subwindows)) ? NULL : &a->subwindows[ind];
+}
 
 static enum parser_error config_window_display(struct parser *parser)
 {
-    GET_WINDOW_FROM_INDEX;
-
+    struct sdlpui_window *window = get_window_from_parser(parser);
     int display = parser_getint(parser, "display");
+
+    if (!window) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
 
     if (display < 0 || display > SDL_GetNumVideoDisplays()) {
         return PARSE_ERROR_OUT_OF_BOUNDS;
@@ -6374,8 +6369,14 @@ static enum parser_error config_window_display(struct parser *parser)
 
 static enum parser_error config_window_fullscreen(struct parser *parser)
 {
-    GET_WINDOW_FROM_INDEX;
-    WINDOW_INIT_OK;
+    struct sdlpui_window *window = get_window_from_parser(parser);
+
+    if (!window) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
+    if (!window->inited) {
+        return PARSE_ERROR_MISSING_RECORD_HEADER;
+    }
 
     const char *mode = parser_getsym(parser, "fullscreen");
     if (streq(mode, "true")) {
@@ -6390,8 +6391,14 @@ static enum parser_error config_window_fullscreen(struct parser *parser)
 
 static enum parser_error config_window_rect(struct parser *parser)
 {
-    GET_WINDOW_FROM_INDEX;
-    WINDOW_INIT_OK;
+    struct sdlpui_window *window = get_window_from_parser(parser);
+
+    if (!window) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
+    if (!window->inited) {
+        return PARSE_ERROR_MISSING_RECORD_HEADER;
+    }
     window->full_rect.x = parser_getint(parser, "x");
     window->full_rect.y = parser_getint(parser, "y");
     window->full_rect.w = parser_getint(parser, "w");
@@ -6402,9 +6409,15 @@ static enum parser_error config_window_rect(struct parser *parser)
 
 static enum parser_error config_window_renderer(struct parser *parser)
 {
-    GET_WINDOW_FROM_INDEX;
-    WINDOW_INIT_OK;
+    struct sdlpui_window *window = get_window_from_parser(parser);
     const char *type = parser_getsym(parser, "type");
+
+    if (!window) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
+    if (!window->inited) {
+        return PARSE_ERROR_MISSING_RECORD_HEADER;
+    }
 
     if (streq(type, "hardware")) {
         window->config->renderer_flags = SDL_RENDERER_ACCELERATED;
@@ -6419,9 +6432,15 @@ static enum parser_error config_window_renderer(struct parser *parser)
 
 static enum parser_error config_window_wallpaper_path(struct parser *parser)
 {
-    GET_WINDOW_FROM_INDEX;
-    WINDOW_INIT_OK;
+    struct sdlpui_window *window = get_window_from_parser(parser);
     const char *path = parser_getstr(parser, "path");
+
+    if (!window) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
+    if (!window->inited) {
+        return PARSE_ERROR_MISSING_RECORD_HEADER;
+    }
     if (streq(path, "default")) {
         char buf[4096];
         path_build(buf, sizeof(buf), DEFAULT_WALLPAPER_DIR, DEFAULT_WALLPAPER);
@@ -6436,9 +6455,15 @@ static enum parser_error config_window_wallpaper_path(struct parser *parser)
 
 static enum parser_error config_window_wallpaper_mode(struct parser *parser)
 {
-    GET_WINDOW_FROM_INDEX;
-    WINDOW_INIT_OK;
+    struct sdlpui_window *window = get_window_from_parser(parser);
     const char *mode = parser_getstr(parser, "mode");
+
+    if (!window) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
+    if (!window->inited) {
+        return PARSE_ERROR_MISSING_RECORD_HEADER;
+    }
 
     if (streq(mode, "none")) {
         window->wallpaper.mode = WALLPAPER_DONT_SHOW;
@@ -6457,15 +6482,18 @@ static enum parser_error config_window_wallpaper_mode(struct parser *parser)
 
 static enum parser_error config_window_font(struct parser *parser)
 {
-    GET_WINDOW_FROM_INDEX;
-    WINDOW_INIT_OK;
+    struct sdlpui_window *window = get_window_from_parser(parser);
     const char *name = parser_getstr(parser, "name");
     int size = parser_getint(parser, "size");
 
-    /*
-     * Checking whether the font is usable will be done in
-     * load_status_bar().
-     */
+    if (!window) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
+    if (!window->inited) {
+        return PARSE_ERROR_MISSING_RECORD_HEADER;
+    }
+
+    /* Checking whether the font is usable will be done in load_window(). */
     window->config->font_name = string_make(name);
     window->config->font_size = size;
 
@@ -6474,8 +6502,14 @@ static enum parser_error config_window_font(struct parser *parser)
 
 static enum parser_error config_window_graphics(struct parser *parser)
 {
-    GET_WINDOW_FROM_INDEX;
-    WINDOW_INIT_OK;
+    struct sdlpui_window *window = get_window_from_parser(parser);
+
+    if (!window) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
+    if (!window->inited) {
+        return PARSE_ERROR_MISSING_RECORD_HEADER;
+    }
 
     int id = parser_getint(parser, "id");
 
@@ -6490,8 +6524,14 @@ static enum parser_error config_window_graphics(struct parser *parser)
 
 static enum parser_error config_window_tile_scale(struct parser *parser)
 {
-    GET_WINDOW_FROM_INDEX;
-    WINDOW_INIT_OK;
+    struct sdlpui_window *window = get_window_from_parser(parser);
+
+    if (!window) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
+    if (!window->inited) {
+        return PARSE_ERROR_MISSING_RECORD_HEADER;
+    }
 
     if (window->graphics.id != GRAPHICS_NONE) {
         if (streq(parser_getsym(parser, "which"), "height")) {
@@ -6508,13 +6548,19 @@ static enum parser_error config_window_tile_scale(struct parser *parser)
 
 static enum parser_error config_subwindow_window(struct parser *parser)
 {
-    GET_SUBWINDOW_FROM_INDEX;
-
+    struct subwindow *subwindow = get_subwindow_from_parser(parser);
+    struct my_app *a = parser_priv(parser);
+    struct sdlpui_window *window;
     unsigned windex = parser_getuint(parser, "windex");
-    if (windex >= N_ELEMENTS(g_windows)) {
+
+    if (!subwindow) {
         return PARSE_ERROR_OUT_OF_BOUNDS;
     }
-    struct window *window = &g_windows[windex];
+
+    if (windex >= N_ELEMENTS(a->windows)) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
+    window = &a->windows[windex];
     if (!window->inited) {
         return PARSE_ERROR_NON_SEQUENTIAL_RECORDS;
     }
@@ -6538,8 +6584,14 @@ static enum parser_error config_subwindow_window(struct parser *parser)
 
 static enum parser_error config_subwindow_rect(struct parser *parser)
 {
-    GET_SUBWINDOW_FROM_INDEX;
-    SUBWINDOW_INIT_OK;
+    struct subwindow *subwindow = get_subwindow_from_parser(parser);
+
+    if (!subwindow) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
+    if (!subwindow->inited) {
+        return PARSE_ERROR_MISSING_RECORD_HEADER;
+    }
 
     subwindow->full_rect.x = parser_getint(parser, "x");
     subwindow->full_rect.y = parser_getint(parser, "y");
@@ -6551,11 +6603,16 @@ static enum parser_error config_subwindow_rect(struct parser *parser)
 
 static enum parser_error config_subwindow_font(struct parser *parser)
 {
-    GET_SUBWINDOW_FROM_INDEX;
-    SUBWINDOW_INIT_OK;
-
+    struct subwindow *subwindow = get_subwindow_from_parser(parser);
     const char *name = parser_getstr(parser, "name");
     int size = parser_getint(parser, "size");
+
+    if (!subwindow) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
+    if (!subwindow->inited) {
+        return PARSE_ERROR_MISSING_RECORD_HEADER;
+    }
 
     /*
      * Checking whether the font is usable will be done in load_subwindow().
@@ -6568,10 +6625,16 @@ static enum parser_error config_subwindow_font(struct parser *parser)
 
 static enum parser_error config_subwindow_borders(struct parser *parser)
 {
-    GET_SUBWINDOW_FROM_INDEX;
-    SUBWINDOW_INIT_OK;
-
+    struct subwindow *subwindow = get_subwindow_from_parser(parser);
     const char *borders = parser_getsym(parser, "borders");
+
+    if (!subwindow) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
+    if (!subwindow->inited) {
+        return PARSE_ERROR_MISSING_RECORD_HEADER;
+    }
+
     if (streq(borders, "true")) {
         subwindow->borders.visible = true;
     } else if (streq(borders, "false")) {
@@ -6585,10 +6648,17 @@ static enum parser_error config_subwindow_borders(struct parser *parser)
 
 static enum parser_error config_subwindow_top(struct parser *parser)
 {
-    GET_SUBWINDOW_FROM_INDEX;
-    SUBWINDOW_INIT_OK;
-
+    struct subwindow *subwindow = get_subwindow_from_parser(parser);
     const char *top = parser_getsym(parser, "top");
+    const char *always = parser_getsym(parser, "always");
+
+    if (!subwindow) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
+    if (!subwindow->inited) {
+        return PARSE_ERROR_MISSING_RECORD_HEADER;
+    }
+
     if (streq(top, "true")) {
         subwindow->top = true;
     } else if (streq(top, "false")) {
@@ -6597,7 +6667,6 @@ static enum parser_error config_subwindow_top(struct parser *parser)
         return PARSE_ERROR_INVALID_VALUE;
     }
 
-    const char *always = parser_getsym(parser, "always");
     if (streq(always, "true")) {
         subwindow->always_top = true;
     } else if (streq(always, "false")) {
@@ -6611,10 +6680,15 @@ static enum parser_error config_subwindow_top(struct parser *parser)
 
 static enum parser_error config_subwindow_alpha(struct parser *parser)
 {
-    GET_SUBWINDOW_FROM_INDEX;
-    SUBWINDOW_INIT_OK;
-
+    struct subwindow *subwindow = get_subwindow_from_parser(parser);
     int alpha = parser_getint(parser, "alpha");
+
+    if (!subwindow) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
+    if (!subwindow->inited) {
+        return PARSE_ERROR_MISSING_RECORD_HEADER;
+    }
 
     if (alpha < 0 || alpha > DEFAULT_ALPHA_FULL) {
         return PARSE_ERROR_INVALID_VALUE;
@@ -6624,20 +6698,46 @@ static enum parser_error config_subwindow_alpha(struct parser *parser)
 
     return PARSE_ERROR_NONE;
 }
-#undef GET_WINDOW_FROM_INDEX
-#undef WINDOW_INIT_OK
-#undef GET_SUBWINDOW_FROM_INDEX
-#undef SUBWINDOW_INIT_OK
+
+static enum parser_error config_menu_shortcut(struct parser *parser)
+{
+    struct my_app *a = parser_priv(parser);
+    unsigned int ind = parser_getuint(parser, "index");
+    const char *keypress_str = parser_getstr(parser, "keypress");
+
+    if (ind >= MAX_WINDOWS) {
+        return PARSE_ERROR_OUT_OF_BOUNDS;
+    }
+    if (!*keypress_str || streq(keypress_str, "None")) {
+        a->menu_shortcuts[ind] = KEYPRESS_NULL;
+    } else {
+        struct keypress buf[2];
+
+        buf[0].type = EVT_NONE;
+        buf[1].type = EVT_NONE;
+        keypress_from_text(buf, N_ELEMENTS(buf), keypress_str);
+        if (buf[0].type == EVT_KBRD && buf[1].type == EVT_NONE) {
+            /* Got exactly one keystroke. */
+            a->menu_shortcuts[ind] = buf[0];
+        } else {
+            /* Treat anything else as no shortcut. */
+            a->menu_shortcuts[ind] = KEYPRESS_NULL;
+        }
+    }
+    return PARSE_ERROR_NONE;
+}
 
 static enum parser_error config_kp_as_mod(struct parser *parser)
 {
-    g_kp_as_mod = parser_getint(parser, "enabled");
+    struct my_app *a = parser_priv(parser);
+
+    a->kp_as_mod = (parser_getint(parser, "enabled") != 0);
     return PARSE_ERROR_NONE;
 }
 
 static enum parser_error config_view_map_hook_mod(struct parser *parser)
 {
-    view_map_hook_mod = parser_getint(parser, "enabled");
+    view_map_hook_mod = (parser_getint(parser, "enabled") != 0);
     return PARSE_ERROR_NONE;
 }
 
@@ -6653,7 +6753,7 @@ static enum parser_error config_music_volume(struct parser *parser)
     return PARSE_ERROR_NONE;
 }
 
-static struct parser *init_parse_config(void)
+static struct parser *init_parse_config(struct my_app *a)
 {
     struct parser *parser = parser_new();
     
@@ -6688,10 +6788,15 @@ static struct parser *init_parse_config(void)
             config_subwindow_top);
     parser_reg(parser, "subwindow-alpha uint index int alpha",
             config_subwindow_alpha);
+
+    parser_reg(parser, "menu-shortcut uint index str keypress",
+            config_menu_shortcut);
     parser_reg(parser, "kp-as-modifier int enabled", config_kp_as_mod);
     parser_reg(parser, "map-modifier int enabled", config_view_map_hook_mod);
     parser_reg(parser, "sound-volume int sound_volume", config_sound_volume);
     parser_reg(parser, "music-volume int music_volume", config_music_volume);
+
+    parser_setpriv(parser, a);
 
     return parser;
 }
@@ -6709,22 +6814,24 @@ static void print_error(const char *name, struct parser *parser)
             parser_error_str[state.error]);
 }
 
-static bool read_config_file(void)
+static bool read_config_file(struct my_app *a)
 {
-    ang_file *config = file_open(g_config_file, MODE_READ, FTYPE_TEXT);
+    char line[1024];
+    ang_file *config = file_open(a->config_file, MODE_READ, FTYPE_TEXT);
+    struct parser *parser;
+    errr error = PARSE_ERROR_NONE;
+
     if (config == NULL) {
         /* not an error, its ok for a config file to not exist */
         return false;
     }
 
-    char line[1024];
-    struct parser *parser = init_parse_config();
-    errr error = 0;
+    parser = init_parse_config(a);
 
     while (file_getl(config, line, sizeof(line))) {
         error = parser_parse(parser, line);
         if (error != PARSE_ERROR_NONE) {
-            print_error(g_config_file, parser);
+            print_error(a->config_file, parser);
             break;
         }
     }

--- a/src/client/ui-event.h
+++ b/src/client/ui-event.h
@@ -157,6 +157,15 @@ struct keypress
 };
 
 /*
+ * Null keypress constant, for safe initializtion.
+ */
+static struct keypress const KEYPRESS_NULL = {
+    .type = EVT_NONE,
+    .code = 0,
+    .mods = 0
+};
+
+/*
  * Union type to hold information about any given event.
  */
 typedef union

--- a/src/sdl2/pui-ctrl.c
+++ b/src/sdl2/pui-ctrl.c
@@ -1,0 +1,2539 @@
+/**
+ * \file sdl2/pui-ctrl.c
+ * \brief Define handlers for simple controls used by the primitive UI toolkit
+ * for SDL2.
+ *
+ * Copyright (c) 2023 Eric Branlund
+ *
+ * This work is free software; you can redistribute it and/or modify it
+ * under the terms of either:
+ *
+ * a) the GNU General Public License as published by the Free Software
+ *    Foundation, version 2, or
+ *
+ * b) the "Angband licence":
+ *    This software may be copied and distributed for educational, research,
+ *    and not for profit purposes provided that this copyright and statement
+ *    are included in all such copies.  Other copyrights may also apply.
+ */
+
+#include "pui-ctrl.h"
+#include "pui-dlg.h"
+#include "pui-misc.h"
+
+
+static void render_image(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, SDL_Renderer *r);
+static void resize_image(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int width, int height);
+static void query_image_natural_size(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        int *width, int *height);
+static void cleanup_image(struct sdlpui_control *c);
+
+static void change_label_caption(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const char *new_caption);
+static void render_label(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, SDL_Renderer *r);
+static void resize_label(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int width, int height);
+static void query_label_natural_size(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        int *width, int *height);
+static void cleanup_label(struct sdlpui_control *c);
+
+static void change_pb_caption(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const char *new_caption);
+static void render_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, SDL_Renderer *r);
+static void respond_default_pb(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        enum sdlpui_action_hint hint);
+static void gain_key_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int comp_ind);
+static void lose_key_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, bool following_mouse);
+static void gain_mouse_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int comp_ind);
+static void lose_mouse_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+static void arm_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, enum sdlpui_action_hint hint);
+static void disarm_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, enum sdlpui_action_hint hint);
+static int get_pb_interactable_component(struct sdlpui_control *c, bool first);
+static void resize_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int width, int height);
+static void query_pb_natural_size(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        int *width, int *height);
+static bool is_pb_disabled(const struct sdlpui_control *c);
+static bool set_pb_disabled(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, bool disabled);
+static int get_pb_tag(const struct sdlpui_control *c);
+static int set_pb_tag(struct sdlpui_control *c, int new_tag);
+static void cleanup_pb(struct sdlpui_control *c);
+
+static bool handle_mb_mousemove(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const struct SDL_MouseMotionEvent *e);
+static bool handle_mb_mousewheel(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const struct SDL_MouseWheelEvent *e);
+static void change_mb_caption(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const char *new_caption);
+static void render_mb(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        SDL_Renderer *r);
+static void respond_default_mb(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        enum sdlpui_action_hint hint);
+static void gain_key_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int comp_ind);
+static void lose_key_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, bool following_mouse);
+static void gain_mouse_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int comp_ind);
+static void lose_mouse_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+static void lose_child_mb(struct sdlpui_control *c,
+        struct sdlpui_dialog *child);
+static void arm_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, enum sdlpui_action_hint hint);
+static void disarm_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, enum sdlpui_action_hint hint);
+static int get_mb_interactable_component(struct sdlpui_control *c, bool first);
+static bool step_within_mb(struct sdlpui_control *c, bool forward);
+static int get_mb_interactable_component_at(struct sdlpui_control *c, Sint32 x,
+        Sint32 y);
+static void resize_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int width, int height);
+static void query_mb_natural_size(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        int *width, int *height);
+static bool is_mb_disabled(const struct sdlpui_control *c);
+static bool set_mb_disabled(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, bool disabled);
+static int get_mb_tag(const struct sdlpui_control *c);
+static int set_mb_tag(struct sdlpui_control *c, int new_tag);
+static void cleanup_mb(struct sdlpui_control *c);
+
+Uint32 SDLPUI_CTRL_IMAGE = 0;
+Uint32 SDLPUI_CTRL_LABEL = 0;
+Uint32 SDLPUI_CTRL_MENU_BUTTON = 0;
+Uint32 SDLPUI_CTRL_PUSH_BUTTON = 0;
+
+/* Function table for sdlpui_image */
+static const struct sdlpui_control_funcs image_funcs = {
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    render_image,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    resize_image,
+    query_image_natural_size,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    cleanup_image
+};
+
+/* Function table for sdlpui_label */
+static const struct sdlpui_control_funcs label_funcs = {
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    change_label_caption,
+    render_label,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    resize_label,
+    query_label_natural_size,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    cleanup_label
+};
+
+/* Function table for sdlpui_push_button */
+const struct sdlpui_control_funcs push_button_funcs = {
+    sdlpui_control_handle_key,
+    NULL,
+    NULL,
+    sdlpui_control_handle_mouseclick,
+    sdlpui_control_handle_mousemove,
+    NULL,
+    change_pb_caption,
+    render_pb,
+    respond_default_pb,
+    gain_key_pb,
+    lose_key_pb,
+    gain_mouse_pb,
+    lose_mouse_pb,
+    NULL,
+    arm_pb,
+    disarm_pb,
+    get_pb_interactable_component,
+    NULL,
+    NULL,
+    resize_pb,
+    query_pb_natural_size,
+    is_pb_disabled,
+    set_pb_disabled,
+    get_pb_tag,
+    set_pb_tag,
+    cleanup_pb
+};
+
+/* Function table for sdlpui_menu_button */
+static const struct sdlpui_control_funcs menu_button_funcs = {
+    sdlpui_control_handle_key,
+    NULL,
+    NULL,
+    sdlpui_control_handle_mouseclick,
+    handle_mb_mousemove,
+    handle_mb_mousewheel,
+    change_mb_caption,
+    render_mb,
+    respond_default_mb,
+    gain_key_mb,
+    lose_key_mb,
+    gain_mouse_mb,
+    lose_mouse_mb,
+    lose_child_mb,
+    arm_mb,
+    disarm_mb,
+    get_mb_interactable_component,
+    step_within_mb,
+    get_mb_interactable_component_at,
+    resize_mb,
+    query_mb_natural_size,
+    is_mb_disabled,
+    set_mb_disabled,
+    get_mb_tag,
+    set_mb_tag,
+    cleanup_mb
+};
+
+
+static void render_image(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, SDL_Renderer *r)
+{
+    struct sdlpui_image *ip;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_IMAGE && c->priv);
+    ip = c->priv;
+    SDLPUI_RENDER_TRACER("image", c, "(none)", c->rect, ip->image_rect,
+        d->texture);
+
+    if (ip->image_rect.w > 0 && ip->image_rect.h > 0) {
+        SDL_Rect dst_r = ip->image_rect;
+
+        /* Get the coordinates relative to the dialog. */
+        dst_r.x += c->rect.x;
+        dst_r.y += c->rect.y;
+        if (!d->texture) {
+            /*
+             * Rendering directly to the window's buffer, so use
+             * its coordinates.
+             */
+            dst_r.x += d->rect.x;
+            dst_r.y += d->rect.y;
+        }
+        SDL_RenderCopy(r, ip->image, NULL, &dst_r);
+    }
+}
+
+
+static void resize_image(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int width, int height)
+{
+    struct sdlpui_image *ip;
+    int tw, th, mhor, mver, nw, nh;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_IMAGE && c->priv);
+    ip = c->priv;
+
+    if (SDL_QueryTexture(ip->image, NULL, NULL, &tw, &th)) {
+        SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+            "SDL_QueryTexture() failed: %s", SDL_GetError());
+        sdlpui_force_quit();
+    }
+    mhor = ip->left_margin + ip->right_margin;
+    mver = ip->top_margin + ip->bottom_margin;
+    nw = tw + mhor;
+    nh = th + mver;
+
+    if (width <= mhor || height <= mver) {
+        /* No room to display anything at all. */
+        ip->image_rect.x = 0;
+        ip->image_rect.y = 0;
+        ip->image_rect.w = 0;
+        ip->image_rect.h = 0;
+        return;
+    }
+    if (width >= nw && height >= nh) {
+        /*
+         * Can display at the native size.  The internal rectangle
+         * has the same dimensions as the image.
+         */
+        ip->image_rect.w = tw;
+        ip->image_rect.h = th;
+    } else {
+        /*
+         * Set the internal rectangle dimensions to keep close to the
+         * original aspect ratio.
+         */
+        long shor = (width >= nw) ?
+            100L :
+            (100L * tw + (width - mhor) / 2) / (width - mhor);
+        long sver = (height >= nh) ?
+            100L :
+            (100L * th + (height - mver) / 2) / (height - mver);
+        long scale = (shor <= sver) ? shor : sver;
+
+        ip->image_rect.w = (int)((tw * scale + 50L) / 100L);
+        ip->image_rect.h = (int)((th * scale + 50L) / 100L);
+        if (ip->image_rect.w < 1) {
+            ip->image_rect.w = 1;
+        }
+        if (ip->image_rect.h < 1) {
+            ip->image_rect.h = 1;
+        }
+    }
+
+    /*
+     * In x, honor the alignment specified when created.  In y, center if
+     * the full size of the control exceeds the inner rectangle's height
+     * plus the vertical margins.
+     */
+    SDL_assert(width >= ip->image_rect.w + mhor);
+    switch (ip->halign) {
+    case SDLPUI_HOR_LEFT:
+        ip->image_rect.x = ip->left_margin;
+        break;
+
+    case SDLPUI_HOR_RIGHT:
+        ip->image_rect.x = width - ip->image_rect.w - ip->right_margin;
+        break;
+
+    default:
+        ip->image_rect.x = (width - ip->image_rect.w - mhor) / 2
+            + ip->left_margin;
+        break;
+    }
+    SDL_assert(height >= ip->image_rect.h + mver);
+    ip->image_rect.y = (height - ip->image_rect.h - mver) / 2
+        + ip->top_margin;
+    c->rect.w = width;
+    c->rect.h = height;
+}
+
+
+static void query_image_natural_size(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        int *width, int *height)
+{
+    struct sdlpui_image *ip;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_IMAGE && c->priv);
+    ip = c->priv;
+    if (SDL_QueryTexture(ip->image, NULL, NULL, width, height)) {
+        SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+            "SDL_QueryTexture() failed: %s", SDL_GetError());
+        sdlpui_force_quit();
+    }
+    *width += ip->left_margin + ip->right_margin;
+    *height += ip->top_margin + ip->bottom_margin;
+}
+
+
+static void cleanup_image(struct sdlpui_control *c)
+{
+    struct sdlpui_image *ip;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_IMAGE && c->priv);
+    ip = c->priv;
+    SDL_DestroyTexture(ip->image);
+    SDL_free(ip);
+}
+
+
+static void change_label_caption(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const char *new_caption)
+{
+    struct sdlpui_label *lp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_LABEL && c->priv);
+    lp = c->priv;
+    SDL_free(lp->caption);
+    lp->caption = SDL_strdup(new_caption);
+    resize_label(c, d, w, c->rect.w, c->rect.h);
+    d->dirty = true;
+    sdlpui_signal_redraw(w);
+}
+
+
+static void render_label(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, SDL_Renderer *r)
+{
+    const SDL_Color *fg = sdlpui_get_color(w, SDLPUI_COLOR_DIALOG_FG);
+    TTF_Font *font = sdlpui_get_ttf(w);
+    struct sdlpui_label *lp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_LABEL && c->priv);
+    lp = c->priv;
+    SDLPUI_RENDER_TRACER("label", c, lp->caption, c->rect,
+        lp->caption_rect, d->texture);
+
+    if (lp->caption_rect.w > 0 && lp->caption_rect.h > 0) {
+        SDL_Rect dst_r = lp->caption_rect;
+
+        dst_r.x += c->rect.x;
+        dst_r.y += c->rect.y;
+        if (!d->texture) {
+            /*
+             * Rendering directly to the window's buffer, so use
+             * its coordinates.
+             */
+            dst_r.x += d->rect.x;
+            dst_r.y += d->rect.y;
+        }
+        sdlpui_render_utf8_line(r, font, fg, &dst_r, lp->caption);
+    }
+}
+
+
+static void resize_label(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int width, int height)
+{
+    TTF_Font *font = sdlpui_get_ttf(w);
+    struct sdlpui_label *lp;
+    int sw, sh, border, nw, nh;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_LABEL && c->priv);
+    lp = c->priv;
+
+    sdlpui_get_utf8_metrics(font, lp->caption, &sw, &sh);
+    border = 2 * SDLPUI_DEFAULT_CTRL_BORDER;
+    nw = sw + border;
+    nh = sh + border;
+
+    if (width <= border || height <= border) {
+        /* No room to display anything at all. */
+        lp->caption_rect.x = 0;
+        lp->caption_rect.y = 0;
+        lp->caption_rect.w = 0;
+        lp->caption_rect.h = 0;
+        return;
+    }
+
+    /* If necessary, truncate what will be displaced to the given size. */
+    lp->caption_rect.w = (width >= nw) ? sw : width - border;
+    lp->caption_rect.h = (height >= nh) ? sh : height - border;
+
+    /*
+     * In x, honor the alignment specified when created.  In y, center if
+     * the full size of the control exceeds the inner rectangle's height
+     * plus the vertical borders.
+     */
+    SDL_assert(width >= lp->caption_rect.w + border);
+    switch (lp->halign) {
+    case SDLPUI_HOR_LEFT:
+        lp->caption_rect.x = SDLPUI_DEFAULT_CTRL_BORDER;
+        break;
+
+    case SDLPUI_HOR_RIGHT:
+        lp->caption_rect.x = width - lp->caption_rect.w
+            - SDLPUI_DEFAULT_CTRL_BORDER;
+        break;
+
+    default:
+        lp->caption_rect.x = (width - lp->caption_rect.w - border) / 2
+            + SDLPUI_DEFAULT_CTRL_BORDER;
+        break;
+    }
+    SDL_assert(height >= lp->caption_rect.h + border);
+    lp->caption_rect.y = (height - lp->caption_rect.h - border) / 2
+            + SDLPUI_DEFAULT_CTRL_BORDER;
+    c->rect.w = width;
+    c->rect.h = height;
+}
+
+
+static void query_label_natural_size(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        int *width, int *height)
+{
+    TTF_Font *font = sdlpui_get_ttf(w);
+    struct sdlpui_label *lp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_LABEL && c->priv);
+    lp = c->priv;
+
+    sdlpui_get_utf8_metrics(font, lp->caption, width, height);
+    *width += SDLPUI_DEFAULT_CTRL_BORDER * 2;
+    *height += SDLPUI_DEFAULT_CTRL_BORDER * 2;
+}
+
+
+static void cleanup_label(struct sdlpui_control *c)
+{
+    struct sdlpui_label *lp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_LABEL && c->priv);
+    lp = c->priv;
+    SDL_free(lp->caption);
+    SDL_free(lp);
+}
+
+
+static void change_pb_caption(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const char *new_caption)
+{
+    struct sdlpui_label *pbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+    SDL_free(pbp->caption);
+    pbp->caption = SDL_strdup(new_caption);
+    resize_pb(c, d, w, c->rect.w, c->rect.h);
+    d->dirty = true;
+    sdlpui_signal_redraw(w);
+}
+
+
+static void render_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, SDL_Renderer *r)
+{
+    const SDL_Color *fg = sdlpui_get_color(w, SDLPUI_COLOR_DIALOG_FG);
+    const SDL_Color *countersink_color = sdlpui_get_color(w,
+        SDLPUI_COLOR_COUNTERSINK);
+    TTF_Font *font = sdlpui_get_ttf(w);
+    struct sdlpui_push_button *pbp;
+    SDL_Rect dst_r;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+    SDLPUI_RENDER_TRACER("push button", c, pbp->caption, c->rect,
+        pbp->caption_rect, d->texture);
+
+    /*
+     * Always draw a border.  There's one pixel between these to leave
+     * space for indicating whether it's armed or not.
+     */
+    SDL_SetRenderDrawColor(r, countersink_color->r, countersink_color->g,
+        countersink_color->b, countersink_color->a);
+    dst_r = c->rect;
+    if (!d->texture) {
+        /*
+         * Drawing directly to the window's buffer, use its coordinates.
+         */
+        dst_r.x += d->rect.x;
+        dst_r.y += d->rect.y;
+    }
+    SDL_RenderDrawRect(r, &dst_r);
+    dst_r.x += 2;
+    dst_r.y += 2;
+    dst_r.w -= 4;
+    dst_r.h -= 4;
+    SDL_SetRenderDrawColor(r, fg->r, fg->g, fg->b, fg->a);
+    SDL_RenderDrawRect(r, &dst_r);
+
+    if (pbp->has_key || pbp->has_mouse) {
+        /* Strengthen the inner border to signal that it has focus. */
+        ++dst_r.x;
+        ++dst_r.y;
+        dst_r.w -= 2;
+        dst_r.h -= 2;
+        SDL_RenderDrawRect(r, &dst_r);
+    }
+
+    if (!pbp->armed) {
+        /*
+         * Button is not depressed.  Highlight left and top edges
+         * as if there's lighting from the upper left since it
+         * protrudes above the surface.
+         */
+        SDL_Point points[3];
+
+        points[0].x = c->rect.x + 1;
+        points[0].y = c->rect.y + c->rect.h - 2;
+        if (!d->texture) {
+            points[0].x += d->rect.x;
+            points[0].y += d->rect.y;
+        }
+        points[1].x = points[0].x;
+        points[1].y = points[0].y - c->rect.h + 3;
+        points[2].x = points[0].x + c->rect.w - 3;
+        points[2].y = points[1].y;
+        SDL_RenderDrawLines(r, points, 3);
+    }
+
+    if (pbp->caption_rect.h > 0 && pbp->caption_rect.w > 0) {
+        dst_r = pbp->caption_rect;
+        dst_r.x += c->rect.x;
+        dst_r.y += c->rect.y;
+        if (!d->texture) {
+            dst_r.x += d->rect.x;
+            dst_r.y += d->rect.y;
+        }
+        sdlpui_render_utf8_line(r, font, fg, &dst_r, pbp->caption);
+    }
+
+    if (pbp->disabled) {
+        struct sdlpui_stipple *stipple = sdlpui_get_stipple(w);
+
+        dst_r = c->rect;
+        if (!d->texture) {
+            dst_r.x += d->rect.x;
+            dst_r.y += d->rect.y;
+        }
+        dst_r.x += 2;
+        dst_r.y += 2;
+        dst_r.w -= 4;
+        dst_r.h -= 4;
+        sdlpui_stipple_rect(r, stipple, &dst_r);
+    }
+}
+
+
+static void respond_default_pb(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        enum sdlpui_action_hint hint)
+{
+    struct sdlpui_push_button *pbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+    if (!pbp->disabled && pbp->callback) {
+        SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
+            "default action invoked");
+        (pbp->callback)(c, d, w);
+    } else {
+        SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
+            (pbp->disabled) ?
+                ((pbp->callback) ? "default action suppressed; disable yes, callback available" : "default action suppressed; disable yes, callback unavailable") :
+                ((pbp->callback) ? "default action suppressed; disable no, callback available" : "default action suppressed; disable no, callback unavailable"));
+    }
+}
+
+
+static void gain_key_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int comp_ind)
+{
+    struct sdlpui_push_button *pbp;
+
+    SDL_assert(comp_ind == 0 || comp_ind == -1);
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+    if (!pbp->has_key) {
+        SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
+            "gained key focus");
+        pbp->has_key = true;
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+    }
+}
+
+
+static void lose_key_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, bool following_mouse)
+{
+    struct sdlpui_push_button *pbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+    if (pbp->has_key) {
+        SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
+            "lost key focus");
+        pbp->has_key = false;
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+    }
+}
+
+
+static void gain_mouse_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int comp_ind)
+{
+    struct sdlpui_push_button *pbp;
+
+    SDL_assert(comp_ind == 0 || comp_ind == -1);
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+    if (!pbp->has_mouse) {
+        SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
+            "gained mouse focus");
+        pbp->has_mouse = true;
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+    }
+}
+
+
+static void lose_mouse_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e)
+{
+    struct sdlpui_push_button *pbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+    if (pbp->has_mouse) {
+        SDLPUI_EVENT_TRACER("push button", c, pbp->caption,
+            "lost mouse focus");
+        pbp->has_mouse = false;
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+    }
+}
+
+
+static void arm_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, enum sdlpui_action_hint hint)
+{
+    struct sdlpui_push_button *pbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+    if (!pbp->armed) {
+        pbp->armed = true;
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+    }
+}
+
+
+static void disarm_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, enum sdlpui_action_hint hint)
+{
+    struct sdlpui_push_button *pbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+    if (pbp->armed) {
+        pbp->armed = false;
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+    }
+}
+
+
+static int get_pb_interactable_component(struct sdlpui_control *c, bool first)
+{
+    struct sdlpui_push_button *pbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+    return (pbp->disabled) ? 0 : 1;
+}
+
+
+static void resize_pb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int width, int height)
+{
+    TTF_Font *font = sdlpui_get_ttf(w);
+    struct sdlpui_push_button *pbp;
+    int sw, sh, border, nw, nh;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+
+    sdlpui_get_utf8_metrics(font, pbp->caption, &sw, &sh);
+    border = 2 * (SDLPUI_DEFAULT_CTRL_BORDER + 2);
+    nw = sw + border;
+    nh = sh + border;
+
+    if (width <= border || height <= border) {
+        /* No room to display anything at all. */
+        pbp->caption_rect.x = 0;
+        pbp->caption_rect.y = 0;
+        pbp->caption_rect.w = 0;
+        pbp->caption_rect.h = 0;
+        return;
+    }
+
+    /* If necessary, truncate what will be displaced to the given size. */
+    pbp->caption_rect.w = (width >= nw) ? sw : width - border;
+    pbp->caption_rect.h = (height >= nh) ? sh : height - border;
+
+    /*
+     * In x, honor the alignment specified when created.  In y, center if
+     * the full size of the control exceeds the inner rectangle's height
+     * plus the vertical borders.
+     */
+    SDL_assert(width >= pbp->caption_rect.w + border);
+    switch (pbp->halign) {
+    case SDLPUI_HOR_LEFT:
+        pbp->caption_rect.x = SDLPUI_DEFAULT_CTRL_BORDER + 2;
+        break;
+
+    case SDLPUI_HOR_RIGHT:
+        pbp->caption_rect.x = width - pbp->caption_rect.w
+            - SDLPUI_DEFAULT_CTRL_BORDER - 2;
+        break;
+
+    default:
+        pbp->caption_rect.x = (width - pbp->caption_rect.w - border) / 2
+            + SDLPUI_DEFAULT_CTRL_BORDER + 2;
+        break;
+    }
+    SDL_assert(height >= pbp->caption_rect.h + border);
+    pbp->caption_rect.y = (height - pbp->caption_rect.h - border) / 2
+        + SDLPUI_DEFAULT_CTRL_BORDER + 2;
+    c->rect.w = width;
+    c->rect.h = height;
+}
+
+
+static void query_pb_natural_size(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w, int *width,
+        int *height)
+{
+    TTF_Font *font = sdlpui_get_ttf(w);
+    struct sdlpui_push_button *pbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+
+    sdlpui_get_utf8_metrics(font, pbp->caption, width, height);
+    *width += (SDLPUI_DEFAULT_CTRL_BORDER + 2) * 2;
+    *height += (SDLPUI_DEFAULT_CTRL_BORDER + 2) * 2;
+}
+
+
+static bool is_pb_disabled(const struct sdlpui_control *c)
+{
+    const struct sdlpui_push_button *pbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+    return pbp->disabled;
+}
+
+
+static bool set_pb_disabled(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, bool disabled)
+{
+    struct sdlpui_push_button *pbp;
+    bool old_value;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+    old_value = pbp->disabled;
+    if (old_value != disabled) {
+        pbp->disabled = disabled;
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+    }
+    return old_value;
+}
+
+
+static int get_pb_tag(const struct sdlpui_control *c)
+{
+    const struct sdlpui_push_button *pbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+    return pbp->tag;
+}
+
+
+static int set_pb_tag(struct sdlpui_control *c, int new_tag)
+{
+    struct sdlpui_push_button *pbp;
+    int old_tag;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+    old_tag = pbp->tag;
+    pbp->tag = new_tag;
+    return old_tag;
+}
+
+
+static void cleanup_pb(struct sdlpui_control *c)
+{
+    struct sdlpui_push_button *pbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_PUSH_BUTTON && c->priv);
+    pbp = c->priv;
+    SDL_free(pbp->caption);
+    SDL_free(pbp);
+}
+
+
+static void help_mb_popup_submenu(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w)
+{
+    struct sdlpui_menu_button *mbp;
+    int ul_x_win, ul_y_win;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+    SDL_assert(mbp->subtype_code == SDLPUI_MB_SUBMENU);
+
+    SDLPUI_EVENT_TRACER("menu submenu button", c, mbp->caption,
+        "popping up child menu");
+
+    ul_x_win = d->rect.x + c->rect.x;
+    ul_y_win = d->rect.y + c->rect.y;
+    switch (mbp->v.submenu.placement) {
+    case SDLPUI_CHILD_MENU_ABOVE:
+        ul_y_win -= mbp->v.submenu.child->rect.h;
+        break;
+
+    case SDLPUI_CHILD_MENU_BELOW:
+        ul_y_win += c->rect.h;
+        break;
+
+    case SDLPUI_CHILD_MENU_LEFT:
+        ul_x_win -= mbp->v.submenu.child->rect.w;
+        break;
+
+    case SDLPUI_CHILD_MENU_RIGHT:
+        ul_x_win += c->rect.w;
+        break;
+
+    default:
+        SDL_assert(0);
+    }
+    mbp->v.submenu.child = (*mbp->v.submenu.creator)(c, d, w, ul_x_win,
+        ul_y_win);
+
+    SDL_assert(d->ftb->set_child);
+    (*d->ftb->set_child)(d, mbp->v.submenu.child);
+    if (mbp->v.submenu.child->pop_callback) {
+        (*mbp->v.submenu.child->pop_callback)(mbp->v.submenu.child,
+            w, true);
+    }
+    sdlpui_dialog_push_to_top(w, mbp->v.submenu.child);
+}
+
+
+static bool handle_mb_mousemove(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const struct SDL_MouseMotionEvent *e)
+{
+    /*
+     * Ignore moution events while a mouse button is pressed (at least up
+     * to the point that the mouse leaves the window).
+     */
+    if (e->state != 0) {
+        return true;
+    }
+    if (sdlpui_is_in_control(c, d, e->x, e->y)) {
+        /*
+         * ranged_int buttons care whether the mouse is in the left or
+         * right side of the button.  Otherwise, motion within the
+         * button doesn't matter.
+         */
+        struct sdlpui_menu_button *mbp;
+
+        SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+        mbp = c->priv;
+        if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
+            int old = mbp->has_mouse;
+
+            if (e->x <= d->rect.x + c->rect.x + c->rect.w / 2) {
+                mbp->has_mouse = (mbp->v.ranged_int.curr
+                    > mbp->v.ranged_int.min) ? 1 : 0;
+            } else {
+                mbp->has_mouse = (mbp->v.ranged_int.curr
+                    < mbp->v.ranged_int.max) ? 2 : 0;
+            }
+            if (old != mbp->has_mouse) {
+                if (!mbp->has_mouse) {
+#ifndef NDEBUG
+                    size_t ecap_sz =
+                        SDL_strlen(mbp->caption) + 16;
+                    char *ecap = SDL_malloc(ecap_sz);
+
+                    (void)SDL_snprintf(ecap, ecap_sz,
+                        mbp->caption,
+                        mbp->v.ranged_int.curr);
+                    SDLPUI_EVENT_TRACER("menu ranged int",
+                        c, ecap, "lost mouse focus");
+                    SDL_free(ecap);
+#endif
+                    d->c_mouse = NULL;
+                } else if (!old) {
+#ifndef NDEBUG
+                    size_t ecap_sz =
+                        SDL_strlen(mbp->caption) + 16;
+                    char *ecap = SDL_malloc(ecap_sz);
+
+                    (void)SDL_snprintf(ecap, ecap_sz,
+                        mbp->caption,
+                        mbp->v.ranged_int.curr);
+                    SDLPUI_EVENT_TRACER("menu ranged int",
+                        c, ecap, "gained mouse focus");
+                    SDL_free(ecap);
+#endif
+                    d->c_mouse = c;
+                }
+                /* Have keyboard focus follow the mouse. */
+                if (mbp->has_key != mbp->has_mouse) {
+                    if (!mbp->has_mouse) {
+#ifndef NDEBUG
+                        size_t ecap_sz =
+                            SDL_strlen(mbp->caption)
+                            + 16;
+                        char *ecap =
+                            SDL_malloc(ecap_sz);
+
+                        (void)SDL_snprintf(ecap,
+                            ecap_sz, mbp->caption,
+                            mbp->v.ranged_int.curr);
+                        SDLPUI_EVENT_TRACER(
+                            "menu ranged int",
+                            c, ecap,
+                            "lost key focus");
+                        SDL_free(ecap);
+#endif
+                        d->c_key = NULL;
+                    } else if (!mbp->has_key) {
+#ifndef NDEBUG
+                        size_t ecap_sz =
+                            SDL_strlen(mbp->caption)
+                            + 16;
+                        char *ecap =
+                            SDL_malloc(ecap_sz);
+
+                        (void)SDL_snprintf(ecap,
+                            ecap_sz, mbp->caption,
+                            mbp->v.ranged_int.curr);
+                        SDLPUI_EVENT_TRACER(
+                            "menu ranged int",
+                            c, ecap,
+                            "gained key focus");
+                        SDL_free(ecap);
+#endif
+                        d->c_key = c;
+                    }
+                    mbp->has_key = mbp->has_mouse;
+                }
+                d->dirty = true;
+                sdlpui_signal_redraw(w);
+            }
+        }
+        return true;
+    }
+    /*
+     * Otherwise, visually indicate that the mouse has left the control
+     * and let the dialog handle the motion to see if it enters another
+     * control.
+     */
+    if (c->ftb->lose_mouse) {
+        (*c->ftb->lose_mouse)(c, d, w, e);
+        if (d->c_mouse == c) {
+            d->c_mouse = NULL;
+        }
+    }
+    return false;
+}
+
+
+static bool handle_mb_mousewheel(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const struct SDL_MouseWheelEvent *e)
+{
+    struct sdlpui_menu_button *mbp;
+    Sint32 change, result;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+
+    /*
+     * ranged_int buttons allow vertical mouse wheel changes to adjust the
+     * value.  Everything else swallows the mouse wheel event without
+     * doing anything.
+     */
+    if (mbp->subtype_code != SDLPUI_MB_RANGED_INT) {
+        return true;
+    }
+
+    change = e->y;
+#if SDL_VERSION_ATLEAST(2, 0, 4)
+    if (e->direction == SDL_MOUSEWHEEL_FLIPPED) {
+        change *= -1;
+    }
+#endif
+    /*
+     * Also flip if the left side of the control has focus (so the default
+     * direction of changes is negative).
+     */
+    if (mbp->has_mouse == 1) {
+        change *= -1;
+    }
+    result = mbp->v.ranged_int.curr + change;
+    if (result < mbp->v.ranged_int.min) {
+        result = mbp->v.ranged_int.min;
+    } else if (result > mbp->v.ranged_int.max) {
+        result = mbp->v.ranged_int.max;
+    }
+    if (mbp->v.ranged_int.curr != result) {
+#ifndef NDEBUG
+        size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
+        char *ecap = SDL_malloc(ecap_sz);
+
+        (void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+            mbp->v.ranged_int.curr);
+        SDLPUI_EVENT_TRACER("menu ranged int", c, ecap,
+            "value changed by mouse wheel");
+        SDL_free(ecap);
+#endif
+        mbp->v.ranged_int.old = mbp->v.ranged_int.curr;
+        mbp->v.ranged_int.curr = (int)result;
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+        if (mbp->callback) {
+            (*mbp->callback)(c, d, w);
+        }
+    } else {
+#ifndef NDEBUG
+        size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
+        char *ecap = SDL_malloc(ecap_sz);
+
+        (void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+            mbp->v.ranged_int.curr);
+        SDLPUI_EVENT_TRACER("menu ranged int", c, ecap,
+            "value left as is by mouse wheel");
+        SDL_free(ecap);
+#endif
+    }
+    return true;
+}
+
+
+static void change_mb_caption(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const char *new_caption)
+{
+    struct sdlpui_label *mbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+    SDL_free(mbp->caption);
+    mbp->caption = SDL_strdup(new_caption);
+    resize_mb(c, d, w, c->rect.w, c->rect.h);
+    d->dirty = true;
+    sdlpui_signal_redraw(w);
+}
+
+
+static void render_mb(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        SDL_Renderer *r)
+{
+    const SDL_Color *fg = sdlpui_get_color(w, SDLPUI_COLOR_MENU_FG);
+    TTF_Font *font = sdlpui_get_ttf(w);
+    struct sdlpui_menu_button *mbp;
+    struct SDL_Rect dst_r;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+    SDLPUI_RENDER_TRACER("menu button", c, mbp->caption, c->rect,
+        mbp->caption_rect, d->texture);
+
+    SDL_SetRenderDrawColor(r, fg->r, fg->g, fg->b, fg->a);
+
+    if (mbp->caption_rect.h > 0 && mbp->caption_rect.w > 0) {
+        dst_r = mbp->caption_rect;
+        dst_r.x += c->rect.x;
+        dst_r.y += c->rect.y;
+        if (!d->texture) {
+            dst_r.x += d->rect.x;
+            dst_r.y += d->rect.y;
+        }
+        if (mbp->subtype_code != SDLPUI_MB_RANGED_INT) {
+            sdlpui_render_utf8_line(r, font, fg, &dst_r,
+                mbp->caption);
+        } else {
+            /* Fill in the current value in the caption. */
+            size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
+            char *ecap = SDL_malloc(ecap_sz);
+
+            (void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+                mbp->v.ranged_int.curr);
+            sdlpui_render_utf8_line(r, font, fg, &dst_r, ecap);
+            SDL_free(ecap);
+        }
+
+        if ((mbp->subtype_code == SDLPUI_MB_TOGGLE
+                || mbp->subtype_code == SDLPUI_MB_INDICATOR)
+                && mbp->v.toggled && mbp->caption_rect.h > 4
+                && c->rect.w > mbp->caption_rect.x
+                    + mbp->caption_rect.w
+                    + SDLPUI_DEFAULT_CTRL_BORDER
+                    + mbp->caption_rect.h) {
+            /*
+             * Add an indicator that this control has been toggled
+             * on.  Use a square drawn on the right side of the
+             * control with a side length set by the height of the
+             * caption minus 4.
+             */
+            dst_r.x = c->rect.x + c->rect.w
+                - SDLPUI_DEFAULT_CTRL_BORDER
+                - (mbp->caption_rect.h - 2);
+            dst_r.y = c->rect.y
+                + (c->rect.h - mbp->caption_rect.h + 4) / 2;
+            dst_r.w = mbp->caption_rect.h - 4;
+            dst_r.h = dst_r.w;
+
+            if (!d->texture) {
+                dst_r.x += d->rect.x;
+                dst_r.y += d->rect.y;
+            }
+            SDL_RenderFillRect(r, &dst_r);
+        }
+    }
+
+    if (mbp->has_key || mbp->has_mouse) {
+        /*
+         * Put a border on it to signal that it has focus.  The border
+         * leaves space for the highlighting that happens if armed.
+         */
+        if (mbp->subtype_code != SDLPUI_MB_RANGED_INT
+                || (mbp->has_key && mbp->has_mouse
+                && mbp->has_key != mbp->has_mouse)) {
+            dst_r = c->rect;
+            if (!d->texture) {
+                /*
+                 * Rendering directly to the window's buffer
+                 * so use its coordinates.
+                 */
+                dst_r.x += d->rect.x;
+                dst_r.y += d->rect.y;
+            }
+            --dst_r.w;
+            --dst_r.h;
+            SDL_RenderDrawRect(r, &dst_r);
+        } else {
+            /*
+             * Only the left or right side has focus.  Don't draw
+             * the line that would split the button in two.
+             */
+            SDL_Point points[4];
+
+            if (mbp->has_key == 1 || mbp->has_mouse == 1) {
+                points[0].x = c->rect.x + c->rect.w / 2;
+                points[0].y = c->rect.y;
+                if (!d->texture) {
+                    points[0].x += d->rect.x;
+                    points[0].y += d->rect.y;
+                }
+                points[1].x = points[0].x - c->rect.w / 2;
+                points[1].y = points[0].y;
+            } else {
+                points[0].x = c->rect.x + c->rect.w / 2 + 1;
+                points[0].y = c->rect.y;
+                if (!d->texture) {
+                    points[0].x += d->rect.x;
+                    points[0].y += d->rect.y;
+                }
+                points[1].x = points[0].x +
+                    (c->rect.w + 1) / 2 - 2;
+                points[1].y = points[0].y;
+            }
+            points[2].x = points[1].x;
+            points[2].y = points[1].y + c->rect.h - 1;
+            points[3].x = points[0].x;
+            points[3].y = points[2].y;
+            SDL_RenderDrawLines(r, points, 4);
+        }
+    }
+
+    if (mbp->armed) {
+        /*
+         * Button is depressed.  Was flat with the surface; now
+         * highlight right and bottom edges as if there's lighting from
+         * the upper left.
+         */
+        SDL_Point points[3];
+        int npt;
+
+        if (mbp->subtype_code != SDLPUI_MB_RANGED_INT
+                || mbp->armed == 3) {
+            points[0].x = c->rect.x;
+            points[0].y = c->rect.y + c->rect.h - 1;
+            if (!d->texture) {
+                points[0].x += d->rect.x;
+                points[0].y += d->rect.y;
+            }
+            points[1].x = points[0].x + c->rect.w - 1;
+            points[1].y = points[0].y;
+            points[2].x = points[1].x;
+            points[2].y = points[1].y - c->rect.h + 1;
+            npt = 3;
+        } else if (mbp->armed == 1) {
+            /* Only the left side is depressed. */
+            points[0].x = c->rect.x;
+            points[0].y = c->rect.y + c->rect.h - 1;
+            if (!d->texture) {
+                points[0].x += d->rect.x;
+                points[0].y += d->rect.y;
+            }
+            points[1].x = points[0].x + c->rect.w / 2;
+            points[1].y = points[0].y;
+            npt = 2;
+        } else {
+            SDL_assert(mbp->armed == 2);
+            /* Only the right side is depressed. */
+            points[0].x = c->rect.x + c->rect.w / 2 + 1;
+            points[0].y = c->rect.y + c->rect.h - 1;
+            if (!d->texture) {
+                points[0].x += d->rect.x;
+                points[0].y += d->rect.y;
+            }
+            points[1].x = points[0].x + (c->rect.w + 1) / 2 - 2;
+            points[1].y = points[0].y;
+            points[2].x = points[1].x;
+            points[2].y = points[1].y - c->rect.h + 1;
+            npt = 3;
+        }
+        SDL_RenderDrawLines(r, points, npt);
+    }
+
+    if (mbp->disabled) {
+        struct sdlpui_stipple *stipple = sdlpui_get_stipple(w);
+
+        dst_r = c->rect;
+        if (!d->texture) {
+            dst_r.x += d->rect.x;
+            dst_r.y += d->rect.y;
+        }
+        sdlpui_stipple_rect(r, stipple, &dst_r);
+    }
+}
+
+
+static void respond_default_mb(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        enum sdlpui_action_hint hint)
+{
+    struct sdlpui_menu_button *mbp;
+    int inci, newi;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+
+    if (mbp->disabled) {
+        return;
+    }
+
+    switch (mbp->subtype_code) {
+    case SDLPUI_MB_SUBMENU:
+        if (!mbp->v.submenu.child) {
+            struct sdlpui_dialog *other_child =
+                sdlpui_get_dialog_child(d);
+
+            if (other_child) {
+                sdlpui_popdown_dialog(other_child, w, false);
+            }
+            help_mb_popup_submenu(c, d, w);
+        } else {
+            SDLPUI_EVENT_TRACER("menu submenu button", c,
+                mbp->caption, "child menu already displayed");
+        }
+        /* Give the first button in the child menu keyboard focus. */
+        if (mbp->v.submenu.child->ftb->goto_first_control) {
+            (*mbp->v.submenu.child->ftb->goto_first_control)(
+                mbp->v.submenu.child, w);
+        }
+        break;
+
+    case SDLPUI_MB_RANGED_INT:
+        if (hint == SDLPUI_ACTION_HINT_KEY
+                || mbp->has_key == mbp->has_mouse) {
+            inci = (mbp->has_key == 1) ?
+                -1 : ((mbp->has_key == 2) ? 1 : 0);
+        } else if (hint == SDLPUI_ACTION_HINT_MOUSE
+                || mbp->has_key == 0) {
+            inci = (mbp->has_mouse == 1) ?
+                -1 : ((mbp->has_mouse == 2) ? 1 : 0);
+        } else if (mbp->has_mouse == 0) {
+            inci = (mbp->has_key == 1) ?
+                -1 : ((mbp->has_key == 2) ? 1 : 0);
+        } else {
+            /* It's not clear what should be done, so do nothing. */
+            inci = 0;
+        }
+        newi = mbp->v.ranged_int.curr + inci;
+        if (newi < mbp->v.ranged_int.min) {
+            newi = mbp->v.ranged_int.min;
+        } else if (newi > mbp->v.ranged_int.max) {
+            newi = mbp->v.ranged_int.max;
+        }
+        if (newi == mbp->v.ranged_int.curr) {
+#ifndef NDEBUG
+            size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
+            char *ecap = SDL_malloc(ecap_sz);
+
+            (void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+                mbp->v.ranged_int.curr);
+            SDLPUI_EVENT_TRACER("menu ranged int", c, ecap,
+                "left unchanged by default response");
+            SDL_free(ecap);
+#endif
+            return;
+        }
+#ifndef NDEBUG
+        {
+            size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
+            char *ecap = SDL_malloc(ecap_sz);
+
+            (void)SDL_snprintf(ecap, ecap_sz, mbp->caption, newi);
+            SDLPUI_EVENT_TRACER("menu ranged int", c, ecap,
+                "changed by default response");
+            SDL_free(ecap);
+        }
+#endif
+        mbp->v.ranged_int.old = mbp->v.ranged_int.curr;
+        mbp->v.ranged_int.curr = newi;
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+        break;
+
+    case SDLPUI_MB_TOGGLE:
+        SDLPUI_EVENT_TRACER("menu toggle", c, mbp->caption,
+            "changed by default response");
+        mbp->v.toggled = !mbp->v.toggled;
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+        break;
+
+    default:
+        break;
+    }
+
+    if (mbp->callback) {
+        (*mbp->callback)(c, d, w);
+    }
+}
+
+
+static void gain_key_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int comp_ind)
+{
+    struct sdlpui_menu_button *mbp;
+    int old;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+
+    SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption,
+        "gained key focus");
+    old = mbp->has_key;
+    if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
+        if (comp_ind < 0) {
+            comp_ind += 2;
+        }
+        SDL_assert(comp_ind == 0 || comp_ind == 1);
+        mbp->has_key = comp_ind + 1;
+    } else if (mbp->subtype_code == SDLPUI_MB_INDICATOR) {
+        SDL_assert(0);
+    } else {
+        SDL_assert(comp_ind == 0 || comp_ind == -1);
+        mbp->has_key = 1;
+    }
+    if (old != mbp->has_key) {
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+    }
+    if (mbp->subtype_code == SDLPUI_MB_SUBMENU && !mbp->v.submenu.child) {
+        help_mb_popup_submenu(c, d, w);
+    }
+}
+
+
+static void lose_key_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, bool following_mouse)
+{
+    struct sdlpui_menu_button *mbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+
+    if (mbp->has_key) {
+        SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption,
+            "lost key focus");
+        mbp->has_key = 0;
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+    }
+    /*
+     * If losing key focus because losing mouse focus, the handling of
+     * the child dialog is done while losing mouse focus and doesn't
+     * have to be done here.
+     */
+    if (!following_mouse && mbp->subtype_code == SDLPUI_MB_SUBMENU
+            && mbp->v.submenu.child) {
+        SDLPUI_EVENT_TRACER("submenu entry", c, mbp->caption,
+            "popping down submenu");
+        sdlpui_popdown_dialog(mbp->v.submenu.child, w, false);
+        mbp->v.submenu.child = NULL;
+    }
+}
+
+
+static void gain_mouse_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int comp_ind)
+{
+    struct sdlpui_menu_button *mbp;
+    int old;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+
+    SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption,
+        "gained mouse focus");
+    old = mbp->has_mouse;
+    if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
+        if (comp_ind < 0) {
+            comp_ind += 2;
+        }
+        SDL_assert(comp_ind == 0 || comp_ind == 1);
+        mbp->has_mouse = comp_ind + 1;
+    } else if (mbp->subtype_code == SDLPUI_MB_INDICATOR) {
+        SDL_assert(0);
+    } else {
+        SDL_assert(comp_ind == 0 || comp_ind == -1);
+        mbp->has_mouse = 1;
+    }
+    if (old != mbp->has_mouse) {
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+    }
+    if (mbp->subtype_code == SDLPUI_MB_SUBMENU && !mbp->v.submenu.child) {
+        help_mb_popup_submenu(c, d, w);
+    }
+}
+
+
+static void lose_mouse_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e)
+
+{
+    struct sdlpui_menu_button *mbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+
+    if (mbp->has_mouse) {
+        SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption,
+            "lost mouse focus");
+        mbp->has_mouse = 0;
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+    }
+    if (mbp->subtype_code == SDLPUI_MB_SUBMENU && mbp->v.submenu.child
+            && (!e || !sdlpui_is_in_dialog(mbp->v.submenu.child,
+            e->x, e->y))) {
+        SDLPUI_EVENT_TRACER("submenu entry", c, mbp->caption,
+            "popping down submenu");
+        sdlpui_popdown_dialog(mbp->v.submenu.child, w, false);
+        mbp->v.submenu.child = NULL;
+    }
+}
+
+
+static void lose_child_mb(struct sdlpui_control *c, struct sdlpui_dialog *child)
+{
+    struct sdlpui_menu_button *mbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+    SDL_assert(mbp->subtype_code == SDLPUI_MB_SUBMENU);
+
+    if (mbp->v.submenu.child) {
+        SDL_assert(mbp->v.submenu.child == child);
+        mbp->v.submenu.child = NULL;
+    }
+}
+
+
+static void arm_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, enum sdlpui_action_hint hint)
+{
+    struct sdlpui_menu_button *mbp;
+    int old;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+
+    SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption, "arming");
+    old = mbp->armed;
+    if (mbp->subtype_code != SDLPUI_MB_RANGED_INT) {
+        mbp->armed = 1;
+    } else {
+        if (hint == SDLPUI_ACTION_HINT_KEY
+                || hint == SDLPUI_ACTION_HINT_NONE) {
+            mbp->armed |= mbp->has_key;
+        }
+        if (hint == SDLPUI_ACTION_HINT_MOUSE
+                || hint == SDLPUI_ACTION_HINT_NONE) {
+            mbp->armed |= mbp->has_mouse;
+        }
+    }
+    if (old != mbp->armed) {
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+    }
+}
+
+
+static void disarm_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, enum sdlpui_action_hint hint)
+{
+    struct sdlpui_menu_button *mbp;
+    int old;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+
+    SDLPUI_EVENT_TRACER("menu entry", c, mbp->caption, "disarming");
+    old = mbp->armed;
+    if (mbp->subtype_code != SDLPUI_MB_RANGED_INT
+            || hint == SDLPUI_ACTION_HINT_NONE) {
+        mbp->armed = 0;
+    } else {
+        if (hint == SDLPUI_ACTION_HINT_KEY) {
+            mbp->armed &= ~mbp->has_key;
+        } else if (hint == SDLPUI_ACTION_HINT_MOUSE) {
+            mbp->armed &= ~mbp->has_mouse;
+        }
+    }
+    if (old != mbp->armed) {
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+    }
+}
+
+
+static int get_mb_interactable_component(struct sdlpui_control *c, bool first)
+{
+    struct sdlpui_menu_button *mbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+
+    if (mbp->disabled || mbp->subtype_code == SDLPUI_MB_INDICATOR) {
+        return 0;
+    }
+    if (mbp->subtype_code != SDLPUI_MB_RANGED_INT) {
+        return 1;
+    }
+    if (first) {
+        if (mbp->v.ranged_int.curr > mbp->v.ranged_int.min) {
+            return 1;
+        } else if (mbp->v.ranged_int.curr < mbp->v.ranged_int.max) {
+            return 2;
+        }
+    } else {
+        if (mbp->v.ranged_int.curr < mbp->v.ranged_int.max) {
+            return 2;
+        } else if (mbp->v.ranged_int.curr > mbp->v.ranged_int.min) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+
+static bool step_within_mb(struct sdlpui_control *c, bool forward)
+{
+    struct sdlpui_menu_button *mbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+
+    SDL_assert(mbp->has_key);
+    if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
+        if (forward) {
+            if (mbp->has_key == 1 && mbp->v.ranged_int.curr
+                    < mbp->v.ranged_int.max) {
+                mbp->has_key = 2;
+                return true;
+            }
+        } else {
+            if (mbp->has_key == 2 && mbp->v.ranged_int.curr
+                    > mbp->v.ranged_int.min) {
+                mbp->has_key = 1;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+
+static int get_mb_interactable_component_at(struct sdlpui_control *c, Sint32 x,
+        Sint32 y)
+{
+    struct sdlpui_menu_button *mbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+
+    if (mbp->disabled || mbp->subtype_code == SDLPUI_MB_INDICATOR
+            || x < c->rect.x || x >= c->rect.x + c->rect.w
+            || y < c->rect.y || y >= c->rect.y + c->rect.h) {
+        return 0;
+    }
+    if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
+        if (x <= c->rect.x + c->rect.w / 2) {
+            return (mbp->v.ranged_int.curr > mbp->v.ranged_int.min) ?
+                1 : 0;
+        }
+        return (mbp->v.ranged_int.curr < mbp->v.ranged_int.max) ? 2 : 0;
+    }
+    return 1;
+}
+
+
+static void resize_mb(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int width, int height)
+{
+    TTF_Font *font = sdlpui_get_ttf(w);
+    struct sdlpui_menu_button *mbp;
+    int sw, sh, tw, border, nw, nh;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+
+    if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
+        size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
+        char *ecap = SDL_malloc(ecap_sz);
+        int wtmp, htmp;
+
+        (void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+            mbp->v.ranged_int.min);
+        sdlpui_get_utf8_metrics(font, ecap, &sw, &sh);
+        (void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+            mbp->v.ranged_int.max);
+        sdlpui_get_utf8_metrics(font, ecap, &wtmp, &htmp);
+        SDL_free(ecap);
+        if (sw < wtmp) {
+            sw = wtmp;
+        }
+        if (sh < htmp) {
+            sh = htmp;
+        }
+    } else {
+        sdlpui_get_utf8_metrics(font, mbp->caption, &sw, &sh);
+    }
+    if (mbp->subtype_code == SDLPUI_MB_TOGGLE
+            || mbp->subtype_code == SDLPUI_MB_INDICATOR) {
+        tw = sh;
+    } else {
+        tw = 0;
+    }
+    border = 2 * SDLPUI_DEFAULT_CTRL_BORDER;
+    nw = sw + tw + border;
+    nh = sh + border;
+
+    if (width <= tw + border || height <= border) {
+        /* No room to display anything at all. */
+        mbp->caption_rect.x = 0;
+        mbp->caption_rect.y = 0;
+        mbp->caption_rect.w = 0;
+        mbp->caption_rect.h = 0;
+        return;
+    }
+
+    /*
+     * If necessary, truncate what will be displaced to the given size.
+     */
+    mbp->caption_rect.h = (height >= nh) ? sh : height - border;
+    if (width >= nw) {
+        mbp->caption_rect.w = sw;
+    } else {
+        mbp->caption_rect.w = width - border - tw;
+    }
+
+    /*
+     * In x, honor the alignment specified when created.  In y, center
+     * if the full size of the control exceeds the inner rectangle's height
+     * plus the vertical borders.
+     */
+    SDL_assert(width >= mbp->caption_rect.w + tw + border);
+    switch(mbp->halign) {
+    case SDLPUI_HOR_LEFT:
+        mbp->caption_rect.x = SDLPUI_DEFAULT_CTRL_BORDER;
+        break;
+
+    case SDLPUI_HOR_RIGHT:
+        mbp->caption_rect.x = width - mbp->caption_rect.w - tw
+            - SDLPUI_DEFAULT_CTRL_BORDER;
+        break;
+
+    default:
+        mbp->caption_rect.x =
+            (width - mbp->caption_rect.w - tw - border) / 2
+            + SDLPUI_DEFAULT_CTRL_BORDER;
+        break;
+    }
+    SDL_assert(height >= mbp->caption_rect.h + border);
+    mbp->caption_rect.y = (height - mbp->caption_rect.h - border) / 2
+        + SDLPUI_DEFAULT_CTRL_BORDER;
+    c->rect.w = width;
+    c->rect.h = height;
+}
+
+
+static void query_mb_natural_size(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        int *width, int *height)
+{
+    TTF_Font *font = sdlpui_get_ttf(w);
+    struct sdlpui_menu_button *mbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+
+    if (mbp->subtype_code == SDLPUI_MB_RANGED_INT) {
+        size_t ecap_sz = SDL_strlen(mbp->caption) + 16;
+        char *ecap = SDL_malloc(ecap_sz);
+        int wtmp, htmp;
+
+        (void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+            mbp->v.ranged_int.min);
+        sdlpui_get_utf8_metrics(font, ecap, width, height);
+        (void)SDL_snprintf(ecap, ecap_sz, mbp->caption,
+            mbp->v.ranged_int.max);
+        sdlpui_get_utf8_metrics(font, ecap, &wtmp, &htmp);
+        SDL_free(ecap);
+        if (*width < wtmp) {
+            *width = wtmp;
+        }
+        if (*height < htmp) {
+            *height = htmp;
+        }
+    } else {
+        sdlpui_get_utf8_metrics(font, mbp->caption, width, height);
+    }
+    if (mbp->subtype_code == SDLPUI_MB_TOGGLE
+            || mbp->subtype_code == SDLPUI_MB_INDICATOR) {
+        *width += (*height) * 3;
+    }
+    *width += SDLPUI_DEFAULT_CTRL_BORDER * 2;
+    *height += SDLPUI_DEFAULT_CTRL_BORDER * 2;
+}
+
+
+static bool is_mb_disabled(const struct sdlpui_control *c)
+{
+    const struct sdlpui_menu_button *mbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+    return mbp->disabled;
+}
+
+
+static bool set_mb_disabled(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, bool disabled)
+{
+    struct sdlpui_menu_button *mbp;
+    bool old_value;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+    old_value = mbp->disabled;
+    if (old_value != disabled) {
+        mbp->disabled = disabled;
+        d->dirty = true;
+        sdlpui_signal_redraw(w);
+    }
+    return old_value;
+}
+
+
+static int get_mb_tag(const struct sdlpui_control *c)
+{
+    const struct sdlpui_menu_button *mbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+    return mbp->tag;
+}
+
+
+static int set_mb_tag(struct sdlpui_control *c, int new_tag)
+{
+    struct sdlpui_menu_button *mbp;
+    int old_tag;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+    old_tag = mbp->tag;
+    mbp->tag = new_tag;
+    return old_tag;
+}
+
+
+static void cleanup_mb(struct sdlpui_control *c)
+{
+    struct sdlpui_menu_button *mbp;
+
+    SDL_assert(c->type_code == SDLPUI_CTRL_MENU_BUTTON && c->priv);
+    mbp = c->priv;
+    SDL_free(mbp->caption);
+    SDL_free(mbp);
+}
+
+
+/**
+ * Determine if a given coordinate, relative to the window, is in a control.
+ *
+ * \param c is the control of interest.
+ * \param d is the dialog that holds the control.
+ * \param x is the horizontal coordinate, relative to the window's upper left
+ * corner, to test.
+ * \param y is the vertical coordinate, relative to the window's upper left
+ * corner, to test.
+ * \return true if (x, y) is in the control and false otherwise.
+ */
+bool sdlpui_is_in_control(const struct sdlpui_control *c,
+        const struct sdlpui_dialog *d, Sint32 x, Sint32 y)
+{
+    if (x < d->rect.x + c->rect.x || y < d->rect.y + c->rect.y
+            || x >= d->rect.x + c->rect.x + c->rect.w
+            || y >= d->rect.y + c->rect.y + c->rect.h) {
+        return false;
+    }
+    return true;
+}
+
+
+/**
+ * Return whether a control is disabled.
+ *
+ * \param c is the control to query.
+ * \return whether or not the control is disabled.  If the control does not
+ * support being disabled/enabled, the return value will be false.
+ */
+bool sdlpui_is_disabled(const struct sdlpui_control *c)
+{
+    return (c->ftb->is_disabled) ? (*c->ftb->is_disabled)(c) : false;
+}
+
+
+/**
+ * Change whether a control is disabled or not.
+ *
+ * \param c is the control to modify.
+ * \param d is the dialog containing the control.
+ * \param w is the window containing the dialog.
+ * \param disabled is whether the control should be disabled or not.
+ * \return whether or not the prior state of the control was disabled.  If
+ * the control does not support changing the disabled/enabled state, the
+ * return value will be false.
+ */
+bool sdlpui_set_disabled(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, bool disabled)
+{
+    return (c->ftb->set_disabled) ?
+        (*c->ftb->set_disabled)(c, d, w, disabled) : false;
+}
+
+
+/**
+ * Get the application-specified tag on a control, if it has one.
+ *
+ * \param c is the control to query.
+ * \return the tag's value.  If the control does not have a tag, the
+ * returned value will be zero.
+ */
+int sdlpui_get_tag(const struct sdlpui_control *c)
+{
+    return (c->ftb->get_tag) ? (*c->ftb->get_tag)(c) : 0;
+}
+
+
+/**
+ * Set the application-specified tag on a control.
+ *
+ * \param c is the control to modify.
+ * \param new_tag is new value for the tag.
+ * \return the old value for the tag.  If the control does not have a tag,
+ * the returned value will be zero and the new tag will not be applied.
+ */
+int sdlpui_set_tag(struct sdlpui_control *c, int new_tag)
+{
+    return (c->ftb->set_tag) ? (*c->ftb->set_tag)(c, new_tag) : 0;
+}
+
+
+/**
+ * Change the caption for a control.
+ *
+ * \param c is the control to modify.
+ * \param d is the dialog containing the control.
+ * \param w is the window containing the dialog.
+ * \param new_caption is the new caption for the control.
+ *
+ * If the control does not support changing the caption, has no effect.
+ * The internals of the control are adjusted for the new caption, but the
+ * external dimensions of the control remain unchanged.
+ */
+void sdlpui_change_caption(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const char *new_caption)
+{
+    if (c->ftb->change_caption) {
+        (*c->ftb->change_caption)(c, d, w, new_caption);
+    }
+}
+
+
+/**
+ * Handle a keyboard event for a simple control.
+ *
+ * \param c is the control receiving the event.  The events handled here
+ * are appropriate if c is simple:  not a compound control and only having
+ * at most one action (the default one; with the associated arming and
+ * disarming).
+ * \param d is the dialog containing the control.
+ * \param w is the window containing the dialog.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the dialog; otherwise return false.
+ */
+bool sdlpui_control_handle_key(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const struct SDL_KeyboardEvent *e)
+{
+    if (e->keysym.sym == SDLK_RETURN) {
+        SDL_Keymod mods = sdlpui_get_interesting_keymods();
+
+        if (e->state == SDL_PRESSED) {
+            if (mods == KMOD_NONE && c->ftb->arm) {
+                (*c->ftb->arm)(c, d, w, SDLPUI_ACTION_HINT_KEY);
+            }
+        } else {
+            /*
+             * Always disarm, regardless of the modifier state,
+             * in case a modifier key was pressed between
+             * depressing and releasing the key.
+             */
+            if (c->ftb->disarm) {
+                (*c->ftb->disarm)(c, d, w,
+                    SDLPUI_ACTION_HINT_KEY);
+            }
+            if (mods == KMOD_NONE) {
+                if (c->ftb->respond_default) {
+                    SDLPUI_EVENT_TRACER("control", c,
+                        "(not extracted)",
+                        "invoking default reponse");
+                    (*c->ftb->respond_default)(c, d, w,
+                        SDLPUI_ACTION_HINT_KEY);
+                } else if (d->ftb->respond_default) {
+                    SDLPUI_EVENT_TRACER("dialog", d,
+                        "(not extracted)",
+                        "invoking default reponse");
+                    (*d->ftb->respond_default)(d, w);
+                }
+            }
+        }
+        return true;
+    }
+
+    /* Let the containing dialog handle everything else. */
+    return false;
+}
+
+
+/*
+ * Handle a mouse button event for a simple control.
+ *
+ * \param c is the control receiving the event.  The events handled here
+ * are appropriate if c is simple:  not a compound control and only having
+ * at most one action (the default one; with the associated arming and
+ * disarming).
+ * \param d is the dialog containing the control.
+ * \param w is the window containing the dialog.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the dialog; otherwise return false.
+ */
+bool sdlpui_control_handle_mouseclick(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const struct SDL_MouseButtonEvent *e)
+{
+    if (e->button == SDL_BUTTON_LEFT) {
+        if (e->state == SDL_PRESSED) {
+            if (c->ftb->arm) {
+                (*c->ftb->arm)(c, d, w,
+                     SDLPUI_ACTION_HINT_MOUSE);
+            }
+        } else {
+            if (c->ftb->disarm) {
+                (*c->ftb->disarm)(c, d, w,
+                    SDLPUI_ACTION_HINT_MOUSE);
+            }
+            if (c->ftb->respond_default) {
+                SDLPUI_EVENT_TRACER("control", c,
+                    "(not extracted)",
+                    "invoking default response");
+                (*c->ftb->respond_default)(c, d, w,
+                    SDLPUI_ACTION_HINT_MOUSE);
+            }
+        }
+    }
+    /* Swallow the event, even if nothing was done. */
+    return true;
+}
+
+
+/*
+ * Handle a mouse motion event for a simple control.
+ *
+ * \param c is the control receiving the event.  The events handled here
+ * are appropriate if c is simple:  not a compound control and only having
+ * at most one action (the default one; with the associated arming and
+ * disarming).
+ * \param d is the dialog containing the control.
+ * \param w is the window containing the dialog.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the dialog; otherwise return false.
+ */
+bool sdlpui_control_handle_mousemove(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const struct SDL_MouseMotionEvent *e)
+{
+    /*
+     * Ignore motion events while a mouse button is pressed (at least
+     * up to the point that the mouse leaves the window).  If the mouse
+     * is moving within the control, it also does nothing.
+     */
+    if (e->state != 0 || sdlpui_is_in_control(c, d, e->x, e->y)) {
+        return true;
+    }
+    /*
+     * Otherwise, visually indicate that the mouse has left the control
+     * and let the dialog handle the motion to see if it enters another
+     * control.
+     */
+    if (c->ftb->lose_mouse) {
+        SDLPUI_EVENT_TRACER("control", c, "(not extracted)",
+            "lost mouse focus");
+        (*c->ftb->lose_mouse)(c, d, w, e);
+        if (d->c_mouse == c) {
+            d->c_mouse = NULL;
+        }
+    }
+    return false;
+}
+
+
+/**
+ * Invoke the given dialog's default action.  Suitable for use as a callback
+ * for buttons.
+ *
+ * \param c is the control which was activated.
+ * \param d is the dialog containing the control.
+ * \param w is the window containing the dialog.
+ */
+void sdlpui_invoke_dialog_default_action(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w)
+{
+    if (d->ftb->respond_default) {
+        SDLPUI_EVENT_TRACER("control", c, "(not extracted)",
+            "invoking containing dialog's default action");
+        (*d->ftb->respond_default)(d, w);
+    }
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for an image control.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param image is the texture holding the image to be used for the control.
+ * The control will assume ownership of the texture and call
+ * SDL_DestroyTexture() on it when the control is destroyed.
+ * \param halign specifies how the image should be horizontally aligned within
+ * the control's bounds if the control is wider than the image.
+ * \param top_margin is the amount of space, in pixels, to leave between the
+ * top of the control and the top of the image.  Must be non-negative.
+ * \param bottom_margin is the amount of space, in pixels, to leave between the
+ * bottom of the control and the bottom of the image.  Must be non-negative.
+ * \param left_margin is the amount of space, in pixels to leave between the
+ * left side of the control and the left side of the image.  Must be
+ * non-negative.
+ * \param right_margin is the amount of space, in pixels to leave between the
+ * right side of the control and the right side of the image.  Must be
+ * non-negative.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_image(struct sdlpui_control *c, SDL_Texture *image,
+        enum sdlpui_hor_align halign, int top_margin, int bottom_margin,
+        int left_margin, int right_margin)
+{
+    struct sdlpui_image *ip = SDL_malloc(sizeof(*ip));
+
+    ip->image = image;
+    ip->halign = halign;
+    ip->top_margin = (top_margin > 0) ? top_margin : 0;
+    ip->bottom_margin = (bottom_margin > 0) ? bottom_margin : 0;
+    ip->left_margin = (left_margin > 0) ? left_margin : 0;
+    ip->right_margin = (right_margin > 0) ? right_margin : 0;
+    c->ftb = &image_funcs;
+    c->priv = ip;
+    c->type_code = SDLPUI_CTRL_IMAGE;
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for a label control.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param caption is the null-terminated UTF-8 string to use as the label.
+ * The contents of caption are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how the label should be horizontally aligned within
+ * the control's bounds if the control is wider than the label.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_label(struct sdlpui_control *c, const char *caption,
+        enum sdlpui_hor_align halign)
+{
+    struct sdlpui_label *lp = SDL_malloc(sizeof(*lp));
+
+    lp->caption = SDL_strdup(caption);
+    lp->halign = halign;
+    c->ftb = &label_funcs;
+    c->priv = lp;
+    c->type_code = SDLPUI_CTRL_LABEL;
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for a push button control.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param caption is the null-terminated UTF-8 string to use as the label.
+ * The contents of caption are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how the label should be horizontally aligned within
+ * the control's bounds if the control is wider than the label.
+ * \param callback is the function to invoke when the button is released.  It
+ * may be NULL.
+ * \param tag is a value the application can use as it wishes to have buttons
+ * with the same callback act differently.
+ * \param disabled will, if true, cause the button to ignore button or keyboard
+ * events and be displayed with an altered appearance until the button is
+ * reenabled.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_push_button(struct sdlpui_control *c, const char *caption,
+        enum sdlpui_hor_align halign, void (*callback)(
+        struct sdlpui_control*, struct sdlpui_dialog*,
+        struct sdlpui_window*), int tag, bool disabled)
+{
+    struct sdlpui_push_button *pbp = SDL_malloc(sizeof(*pbp));
+
+    pbp->caption = SDL_strdup(caption);
+    pbp->callback = callback;
+    pbp->halign = halign;
+    pbp->tag = tag;
+    pbp->disabled = disabled;
+    pbp->has_key = false;
+    pbp->has_mouse = false;
+    pbp->armed = false;
+    c->ftb = &push_button_funcs;
+    c->priv = pbp;
+    c->type_code = SDLPUI_CTRL_PUSH_BUTTON;
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for a menu button control.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param caption is the null-terminated UTF-8 string to use as the label.
+ * The contents of caption are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how the label should be horizontally aligned within
+ * the control's bounds if the control is wider than the label.
+ * \param callback is the function to invoke when the button is released.  It
+ * may be NULL.
+ * \param tag is a value the application can use as it wishes to have buttons
+ * with the same callback act differently.
+ * \param disabled will, if true, cause the button to ignore button or keyboard
+ * events and be displayed with an altered appearance until the button is
+ * reenabled.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_menu_button(struct sdlpui_control *c, const char *caption,
+        enum sdlpui_hor_align halign, void (*callback)(
+        struct sdlpui_control*, struct sdlpui_dialog*,
+        struct sdlpui_window*w), int tag, bool disabled)
+{
+    struct sdlpui_menu_button *mbp = SDL_malloc(sizeof(*mbp));
+
+    mbp->caption = SDL_strdup(caption);
+    mbp->callback = callback;
+    mbp->halign = halign;
+    mbp->tag = tag;
+    mbp->has_key = 0;
+    mbp->has_mouse = 0;
+    mbp->armed = 0;
+    mbp->disabled = disabled;
+    mbp->subtype_code = SDLPUI_MB_NONE;
+    c->ftb = &menu_button_funcs;
+    c->priv = mbp;
+    c->type_code = SDLPUI_CTRL_MENU_BUTTON;
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for a menu indicator control.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param caption is the null-terminated UTF-8 string to use as the label.
+ * The contents of caption are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how the label should be horizontally aligned within
+ * the control's bounds if the control is wider than the label.
+ * \param tag is a value the application can use as it wishes to have otherwise
+ * similar indicators act differently.
+ * \param curr_value is whether or not the indicator is currently on.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_menu_indicator(struct sdlpui_control *c, const char *caption,
+        enum sdlpui_hor_align halign, int tag, bool curr_value)
+{
+    struct sdlpui_menu_button *mbp = SDL_malloc(sizeof(*mbp));
+
+    mbp->caption = SDL_strdup(caption);
+    mbp->callback = NULL;
+    mbp->halign = halign;
+    mbp->tag = tag;
+    mbp->has_key = 0;
+    mbp->has_mouse = 0;
+    mbp->armed = 0;
+    mbp->disabled = false;
+    mbp->subtype_code = SDLPUI_MB_INDICATOR;
+    mbp->v.toggled = curr_value;
+    c->ftb = &menu_button_funcs;
+    c->priv = mbp;
+    c->type_code = SDLPUI_CTRL_MENU_BUTTON;
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for a menu button
+ * controlling an integer parameter limited to a fixed range.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param caption is the null-terminated UTF-8 string to use as the label.
+ * The contents of caption are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how the label should be horizontally aligned within
+ * the control's bounds if the control is wider than the label.
+ * \param callback is the function to invoke when the value associated with
+ * button changes due to a user interface event.  It may be NULL.
+ * \param tag is a value the application can use as it wishes to have buttons
+ * with the same callback act differently.
+ * \param disabled will, if true, cause the button to ignore button or keyboard
+ * events and be displayed with an altered appearance until the button is
+ * reenabled.
+ * \param curr_value is the current value for the integer associated with the
+ * button.
+ * \param min_value is the minimum value for the integer associated with the
+ * button.
+ * \param max_value is the minimum value for the integer associated with the
+ * button.  max_value must be greater than or equal to min_value.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_menu_ranged_int(struct sdlpui_control *c,
+        const char *caption, enum sdlpui_hor_align halign,
+        void (*callback)(struct sdlpui_control*, struct sdlpui_dialog*,
+        struct sdlpui_window*), int tag, bool disabled, int curr_value,
+        int min_value, int max_value)
+{
+    struct sdlpui_menu_button *mbp = SDL_malloc(sizeof(*mbp));
+
+    mbp->caption = SDL_strdup(caption);
+    mbp->callback = callback;
+    mbp->halign = halign;
+    mbp->tag = tag;
+    mbp->has_key = 0;
+    mbp->has_mouse = 0;
+    mbp->armed = 0;
+    mbp->disabled = disabled;
+    mbp->subtype_code = SDLPUI_MB_RANGED_INT;
+    mbp->v.ranged_int.min = min_value;
+    mbp->v.ranged_int.max = max_value;
+    mbp->v.ranged_int.curr = curr_value;
+    mbp->v.ranged_int.old = curr_value;
+    c->ftb = &menu_button_funcs;
+    c->priv = mbp;
+    c->type_code = SDLPUI_CTRL_MENU_BUTTON;
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for a toggleable control
+ * in a menu.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param caption is the null-terminated UTF-8 string to use as the label.
+ * The contents of caption are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how the label should be horizontally aligned within
+ * the control's bounds if the control is wider than the label.
+ * \param callback is the function to invoke when the button is released.  It
+ * may be NULL.
+ * \param tag is a value the application can use as it wishes to have buttons
+ * with the same callback act differently.
+ * \param disabled will, if true, cause the button to ignore button or keyboard
+ * events and be displayed with an altered appearance until the button is
+ * reenabled.
+ * \param curr_value is whether the toggle is currently on.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_menu_toggle(struct sdlpui_control *c, const char *caption,
+        enum sdlpui_hor_align halign, void (*callback)(
+        struct sdlpui_control*, struct sdlpui_dialog*,
+        struct sdlpui_window*), int tag, bool disabled,
+        bool curr_value)
+{
+    struct sdlpui_menu_button *mbp = SDL_malloc(sizeof(*mbp));
+
+    mbp->caption = SDL_strdup(caption);
+    mbp->callback = callback;
+    mbp->halign = halign;
+    mbp->tag = tag;
+    mbp->has_key = 0;
+    mbp->has_mouse = 0;
+    mbp->armed = 0;
+    mbp->disabled = disabled;
+    mbp->subtype_code = SDLPUI_MB_TOGGLE;
+    mbp->v.toggled = curr_value;
+    c->ftb = &menu_button_funcs;
+    c->priv = mbp;
+    c->type_code = SDLPUI_CTRL_MENU_BUTTON;
+}
+
+
+/*
+ * Initializes the contents of c to be appropriate for a menu button that
+ * leads to a nested menu.
+ *
+ * \param c points to the control to be initialized.  Must not be NULL.
+ * \param caption is the null-terminated UTF-8 string to use as the label.
+ * The contents of caption are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how the label should be horizontally aligned within
+ * the control's bounds if the control is wider than the label.
+ * \param creator is the function to invoke to create the nested menu.  It must
+ * not be NULL.  It takes five arguments:  a pointer to the parent control for
+ * menu, a pointer to the parent dialog for that control, a pointer to the
+ * window containing that dialog and control, the x coordinate (relative to
+ * the window) for the upper right corner of the nested menu, and the y
+ * coordinate (relative to the window) for the upper rgith corner of the
+ * nested menu.
+ * \param placement specifies how the nested menu will be placed relative to
+ * the menu button.
+ * \param tag is a value the application can use as it wishes to have otherwise
+ * similar buttons act differently.
+ * \param disabled will, if true, cause the button to ignore button or keyboard
+ * events and be displayed with an altered appearance until the button is
+ * reenabled.
+ *
+ * Note that the bounding rectangle for the control is not set.  The caller
+ * should use c->ftb->resize to set that (perhaps in conjunction with
+ * c->ftb->query_natural_size) and set c->rect.x and c->rect.y directly to
+ * position the control in a dialog.
+ */
+void sdlpui_create_submenu_button(struct sdlpui_control *c, const char *caption,
+        enum sdlpui_hor_align halign, struct sdlpui_dialog *(*creator)(
+        struct sdlpui_control*, struct sdlpui_dialog*,
+        struct sdlpui_window*, int ul_x_win, int ul_y_win),
+        enum sdlpui_child_menu_placement placement, int tag,
+        bool disabled)
+{
+    struct sdlpui_menu_button *mbp = SDL_malloc(sizeof(*mbp));
+
+    mbp->caption = SDL_strdup(caption);
+    mbp->callback = NULL;
+    mbp->halign = halign;
+    mbp->tag = tag;
+    mbp->has_key = 0;
+    mbp->has_mouse = 0;
+    mbp->armed = 0;
+    mbp->disabled = disabled;
+    mbp->subtype_code = SDLPUI_MB_SUBMENU;
+    mbp->v.submenu.creator = creator;
+    mbp->v.submenu.child = NULL;
+    mbp->v.submenu.placement = placement;
+    c->ftb = &menu_button_funcs;
+    c->priv = mbp;
+    c->type_code = SDLPUI_CTRL_MENU_BUTTON;
+}

--- a/src/sdl2/pui-ctrl.h
+++ b/src/sdl2/pui-ctrl.h
@@ -1,0 +1,417 @@
+/**
+ * \file sdl2/pui-ctrl.h
+ * \brief Declare the interface for controls that can be included in menus or
+ * dialogs created by the primitive UI toolkit for SDL2.
+ */
+#ifndef INCLUDED_SDL2_SDLPUI_CONTROL_H
+#define INCLUDED_SDL2_SDLPUI_CONTROL_H
+
+#ifdef WINDOWS
+#include "..\_SDL2\SDL.h"
+#else
+#include "SDL.h" /* SDL_*Event, SDL_Rect, SDL_Renderer, Sint32 */
+#endif
+#include <stdbool.h>
+
+struct sdlpui_control;
+struct sdlpui_dialog;
+struct sdlpui_window;
+
+/*
+ * Default width for empty space around labels, push buttons, and menu buttons
+ */
+#define SDLPUI_DEFAULT_CTRL_BORDER 8
+
+/*
+ * Set out predefined values for the type_code field of struct sdlpui_control.
+ * These are initialized by sdlpui_init().  For custom controls, you can get
+ * a code with sdlpui_register_code().
+ */
+extern Uint32 SDLPUI_CTRL_IMAGE;
+extern Uint32 SDLPUI_CTRL_LABEL;
+extern Uint32 SDLPUI_CTRL_MENU_BUTTON;
+extern Uint32 SDLPUI_CTRL_PUSH_BUTTON;
+
+/*
+ * Set out possible values for the subtype_code field of struct
+ * sdlpui_menu_button.
+ */
+enum sdlpui_menu_button_type {
+    SDLPUI_MB_INVALID = 0,
+    SDLPUI_MB_NONE,
+    SDLPUI_MB_INDICATOR,
+    SDLPUI_MB_RANGED_INT,
+    SDLPUI_MB_SUBMENU,
+    SDLPUI_MB_TOGGLE,
+};
+
+/*
+ * Since mouse focus and keyboard focus can be directed to different controls
+ * within a compound control, provide a hint about the cause for invoking an
+ * action on a control.
+ */
+enum sdlpui_action_hint {
+    SDLPUI_ACTION_HINT_NONE,
+    SDLPUI_ACTION_HINT_KEY,
+    SDLPUI_ACTION_HINT_MOUSE
+};
+
+/* How to horizontally align something (usually a label) in a larger box. */
+enum sdlpui_hor_align {
+    SDLPUI_HOR_INVALID = 0,
+    SDLPUI_HOR_CENTER,
+    SDLPUI_HOR_LEFT,
+    SDLPUI_HOR_RIGHT
+};
+
+/* How to place a created menu relative to its parent control. */
+enum sdlpui_child_menu_placement {
+    SDLPUI_CHILD_MENU_ABOVE,
+    SDLPUI_CHILD_MENU_BELOW,
+    SDLPUI_CHILD_MENU_LEFT,
+    SDLPUI_CHILD_MENU_RIGHT
+};
+
+/* Holds a function table to be used for a class of controls. */
+struct sdlpui_control_funcs {
+    /*
+     * Respond to events.  Return true if the event was handled and
+     * shouldn't be passed on to another handler.  Otherwise, return false.
+     * Any can be NULL if the control doesn't do anything with that type
+     * of event and wants the dialog or window to handle the event.
+     */
+    bool (*handle_key)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const SDL_KeyboardEvent *e);
+    bool (*handle_textin)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const SDL_TextInputEvent *e);
+    bool (*handle_textedit)(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const SDL_TextEditingEvent *e);
+    bool (*handle_mouseclick)(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const SDL_MouseButtonEvent *e);
+    bool (*handle_mousemove)(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const SDL_MouseMotionEvent *e);
+    bool (*handle_mousewheel)(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const SDL_MouseWheelEvent *e);
+    /*
+     * Change the caption for the control.  May be NULL if the control
+     * does not have a caption or otherwise does not want
+     * sdlpui_change_caption() to work with the control.  Does resize
+         * the internals of the control for the new caption but does not
+         * change its external dimensions.
+     */
+    void (*change_caption)(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const char *new_caption);
+    /*
+     * Render the control.  Can be NULL, but then the control will be
+     * invisible.  Assumes the renderer's target has been set to
+     * d->texture.
+     */
+    void (*render)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, SDL_Renderer *r);
+    /* Do the default action for a control.  Can be NULL. */
+    void (*respond_default)(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        enum sdlpui_action_hint hint);
+    /*
+     * Signal that the given control has gained keyboard focus and
+     * perhaps should change its appearance when rendered.  comp_ind is
+     * only relevant for compound controls and is the index of the component
+     * that should receive focus.  Negative indices are relative to the
+     * number of controls in the compound control so -1 is the "last"
+     * control.  Can be NULL.
+     */
+    void (*gain_key)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int comp_ind);
+    /*
+     * Signal that the given control has lost keyboard focus.  Can be NULL.
+     * following_mouse is true if the control is losing key focus because
+     * it is losing mouse focus at the same time.
+     */
+    void (*lose_key)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, bool following_mouse);
+    /*
+     * Signal that the given control has gained mouse focus and
+     * perhaps should change its appearance when rendered.  comp_ind
+     * has the same meaning as for gain_key above.  Can be NULL.
+     */
+    void (*gain_mouse)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int comp_ind);
+    /*
+     * Signal that the given control has lost mouse focus.  Can be NULL.
+     * e is the motion event causing the loss of focus or NULL if focus
+     * is lost for another reason.
+     */
+    void (*lose_mouse)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+    /*
+     * Signal that the child dialog for a control has been removed.  Can
+     * be NULL if the control doesn't create a dialog, set the created
+     * dialog's parent control to the control, or record the pointer
+     * to the dialog.
+     */
+    void (*lose_child)(struct sdlpui_control *c,
+        struct sdlpui_dialog *child);
+    /*
+     * Signal that the control has become armed (i.e. key or mouse button
+     * depressed while the control has focus).  Can be NULL.
+     */
+    void (*arm)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, enum sdlpui_action_hint hint);
+    /*
+     * Signal that the control has become disarmed (i.e. key or mouse button
+     * released while the control has focus).  Can be NULL.
+     */
+    void (*disarm)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, enum sdlpui_action_hint hint);
+    /*
+     * For simple controls, either returns zero (the control doesn't
+     * accept focus) or one (it does).  For compound controls it returns:
+     *     a) Zero if none of the components accepts focus.
+     *     b) If first is true, returns the one-based index of the first
+     *        component that can accept focus.
+     *     c) If first is false, returns the one-based index of the last
+     *        component that can accept focus.
+     * May be NULL:  callers will then assume the control can't accept
+     * focus.
+     */
+    int (*get_interactable_component)(struct sdlpui_control *c, bool first);
+    /*
+     * Step (forward if forward is true; backward otherwise; never wrap
+     * around) between the interactable components within the given
+     * control, assumed to already have key focus, and transfer the key
+     * focus to the result of the step.  Return true if stepping was
+     * possible or false otherwise.  May be NULL:  callers will then assume
+     * that any attempt to step within the control will be ineffective.
+     */
+    bool (*step_within)(struct sdlpui_control *c, bool forward);
+    /*
+     * For a simple control, either returns zero (the control doesn't
+     * accept focus or contain the given coordinates, relative to the
+     * dialog) or one (the control accepts focus and the given coordinates
+     * are in the control).  For a compound control return zero if there's
+     * no component that accepts focus and contains the given coordinates.
+     * May be NULL:  callers will then assume the control is simple,
+     * accepts focus if get_interactable_component is not NULL and
+     * returns a non-zero value, and will test the coordinate directly
+     * against the control's rectangle.
+     */
+    int (*get_interactable_component_at)(struct sdlpui_control *c,
+        Sint32 x, Sint32 y);
+    /*
+     * Resize the control so it has the given dimensions.  May be NULL
+     * if resizing the control is as simple as setting c->rect.w and
+     * c->rect.h to the desired dimensions.
+     */
+    void (*resize)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int width, int height);
+    /*
+     * Set width and height to the natural size for the control.  May not
+     * be NULL.
+     */
+    void (*query_natural_size)(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w, int *width,
+        int *height);
+    /*
+     * Get whether the control is disabled.  May be NULL:  the control
+     * doesn't support enabling/disabling.
+     */
+    bool (*is_disabled)(const struct sdlpui_control *c);
+    /*
+     * Change whether the control is disabled and return whether or not
+     * its prior state was disabled.  May be NULL:  the control doesn't
+     * support enabling/disabling.
+     */
+    bool (*set_disabled)(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, bool disabled);
+    /*
+     * Get the application-assigned tag for a control.  May be NULL:  the
+     * control doesn't support application-assigned tags.
+     */
+    int (*get_tag)(const struct sdlpui_control *c);
+    /*
+     * Change the application-assigned tag for a control and return its
+     * prior tag.  May be NULL:  the control doesn't support
+     * application-assigned tags.
+     */
+    int (*set_tag)(struct sdlpui_control *c, int new_tag);
+    /*
+     * Handle releasing resources for the private data, if any.  May be
+     * NULL to have no special cleanup done.
+     */
+    void (*cleanup)(struct sdlpui_control *c);
+};
+
+/* Represents a button or other sort of control in a dialog or menu. */
+struct sdlpui_control {
+    const struct sdlpui_control_funcs *ftb;
+    /* Holds data specific to the particular type of control. */
+    void *priv;
+    /*
+     * Holds the position, relative to the containing dialog/menu's
+     * upper left corner, and size of the control.
+     */
+    SDL_Rect rect;
+    /* Allow for a check before casting priv to another type. */
+    Uint32 type_code;
+};
+
+/*
+ * Holds the private data for a sdlpui_control used to represent an image for
+ * use in general dialogs.  The corresponding type_code value is
+ * SDLPUI_CTRL_IMAGE.
+ */
+struct sdlpui_image {
+    /* x and y are relative to the (x, y) from the control's rectangle. */
+    SDL_Rect image_rect;
+    SDL_Texture *image;
+    enum sdlpui_hor_align halign;
+    int top_margin, bottom_margin, left_margin, right_margin;
+};
+
+/*
+ * Holds the private data for a sdlpui_control used to represent a single line
+ * label for use in general dialogs.  The corresponding type_code value is
+ * SDLPUI_CTRL_LABEL.
+ */
+struct sdlpui_label {
+    /* x and y are relative to the (x, y) from the control's rectangle. */
+    SDL_Rect caption_rect;
+    char *caption;
+    enum sdlpui_hor_align halign;
+};
+
+/*
+ * Holds the private data for a sdlpui_control used to represent a button in
+ * menu.  The corressponding type_code value is SDLPUI_CTRL_MENU_BUTTON.
+ */
+struct sdlpui_menu_button {
+    SDL_Rect caption_rect;
+    char *caption;
+    /* Invoked by the menu button's respond_default handler. */
+    void (*callback)(struct sdlpui_control*, struct sdlpui_dialog*,
+        struct sdlpui_window *w);
+    enum sdlpui_hor_align halign;
+    /*
+     * This is a hook for the application to differentiate buttons with
+     * the same contents for callback, subtype_code, and v.
+     */
+    int tag;
+    int has_key;    /* 0 = no key focus, 1 = key focus (for ranged_int
+                button, left side has focus), 2 = key focus
+                for right side of ranged_int button */
+    int has_mouse;    /* 0 = no mouse focus, 1 = mouse focus (for ranged_int
+                button, left side has focus), 2 = mouse focus
+                for right side of ranged_int button */
+    int armed;    /* 0 = not depressed, 1 = button depressed (for
+                ranged_int button, left side depressed), 2 =
+                ranged_int button right side depressed,
+                3 = ranged_int button both sides depressed */
+    bool disabled;    /* if true, no response to events and different look */
+    enum sdlpui_menu_button_type subtype_code;
+    union {
+        struct { int min, max, curr, old; } ranged_int;
+        struct {
+            struct sdlpui_dialog *(*creator)(
+                struct sdlpui_control*,
+                struct sdlpui_dialog*,
+                struct sdlpui_window*,
+                int ul_x_win,
+                int ul_y_win);
+            struct sdlpui_dialog *child;
+            enum sdlpui_child_menu_placement placement;
+        } submenu;
+        bool toggled; /* subtype_code is SDLPUI_MB_INDICATOR or
+                    SDLPUI_MB_TOGGLE */
+    } v;
+};
+
+/*
+ * Holds the private data for a sdlpui_control used to represent a push button
+ * used in general dialogs.  The corresponding type_code value is
+ * SDLPUI_CTRL_PUSH_BUTTON.
+ */
+struct sdlpui_push_button {
+    SDL_Rect caption_rect;
+    char *caption;
+    /* Invoked by the push button's respond_default handler. */
+    void (*callback)(struct sdlpui_control*, struct sdlpui_dialog*,
+        struct sdlpui_window*);
+    enum sdlpui_hor_align halign;
+    /*
+     * This is a hook for the application to differentiate push buttons
+     * with the same callback.
+     */
+    int tag;
+    bool disabled;    /* if true, no response to events and different look */
+    bool has_key;    /* if true, has key focus */
+    bool has_mouse;    /* if true, has mouse focus */
+    bool armed;    /* if true, button is depressed */
+};
+
+
+bool sdlpui_is_in_control(const struct sdlpui_control *c,
+        const struct sdlpui_dialog *d, Sint32 x, Sint32 y);
+bool sdlpui_is_disabled(const struct sdlpui_control *c);
+bool sdlpui_set_disabled(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, bool disabled);
+int sdlpui_get_tag(const struct sdlpui_control *c);
+int sdlpui_set_tag(struct sdlpui_control *c, int new_tag);
+void sdlpui_change_caption(struct sdlpui_control *c, struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const char *new_caption);
+
+/* Standard event handlers for simple controls */
+bool sdlpui_control_handle_key(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const struct SDL_KeyboardEvent *e);
+bool sdlpui_control_handle_mouseclick(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const struct SDL_MouseButtonEvent *e);
+bool sdlpui_control_handle_mousemove(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const struct SDL_MouseMotionEvent *e);
+
+/* Standard callbacks for button controls */
+void sdlpui_invoke_dialog_default_action(struct sdlpui_control *c,
+        struct sdlpui_dialog *d, struct sdlpui_window *w);
+
+/* Constructors for controls in generic dialogs */
+void sdlpui_create_image(struct sdlpui_control *c, SDL_Texture *image,
+        enum sdlpui_hor_align halign, int top_margin, int bottom_margin,
+        int left_margin, int right_margin);
+void sdlpui_create_label(struct sdlpui_control *c, const char *caption,
+        enum sdlpui_hor_align halign);
+void sdlpui_create_push_button(struct sdlpui_control *c, const char *caption,
+        enum sdlpui_hor_align halign, void (*callback)(
+        struct sdlpui_control*, struct sdlpui_dialog*,
+        struct sdlpui_window*), int tag, bool disabled);
+
+/* Constructors for controls in menus */
+void sdlpui_create_menu_button(struct sdlpui_control *c, const char *caption,
+        enum sdlpui_hor_align halign, void (*callback)(
+        struct sdlpui_control*, struct sdlpui_dialog*,
+        struct sdlpui_window*), int tag, bool disabled);
+void sdlpui_create_menu_indicator(struct sdlpui_control *c, const char *caption,
+        enum sdlpui_hor_align halign, int tag, bool curr_value);
+void sdlpui_create_menu_ranged_int(struct sdlpui_control *c,
+        const char *caption, enum sdlpui_hor_align halign,
+        void (*callback)(struct sdlpui_control*, struct sdlpui_dialog*,
+        struct sdlpui_window*), int tag, bool disabled, int curr_value,
+        int min_value, int max_value);
+void sdlpui_create_menu_toggle(struct sdlpui_control *c, const char *caption,
+        enum sdlpui_hor_align halign, void (*callback)(
+        struct sdlpui_control*, struct sdlpui_dialog*,
+        struct sdlpui_window*), int tag, bool disabled,
+        bool curr_value);
+void sdlpui_create_submenu_button(struct sdlpui_control *c, const char *caption,
+        enum sdlpui_hor_align halign, struct sdlpui_dialog *(*creator)(
+        struct sdlpui_control*, struct sdlpui_dialog*, struct
+        sdlpui_window*, int ul_x_win, int ul_y_win),
+        enum sdlpui_child_menu_placement placement, int tag,
+        bool disabled);
+
+#endif /* INCLUDED_SDL2_SDLPUI_CONTROL_H */

--- a/src/sdl2/pui-dlg.c
+++ b/src/sdl2/pui-dlg.c
@@ -1,0 +1,2236 @@
+/**
+ * \file sdl2/pui-dlg.c
+ * \brief Define the interface for menus and dialogs created by the primitive
+ * UI toolkit for SDL2.
+ *
+ * Copyright (c) 2023 Eric Branlund
+ *
+ * This work is free software; you can redistribute it and/or modify it
+ * under the terms of either:
+ *
+ * a) the GNU General Public License as published by the Free Software
+ *    Foundation, version 2, or
+ *
+ * b) the "Angband licence":
+ *    This software may be copied and distributed for educational, research,
+ *    and not for profit purposes provided that this copyright and statement
+ *    are included in all such copies.  Other copyrights may also apply.
+ */
+
+#include "pui-dlg.h"
+#include "pui-misc.h"
+#include "pui-win.h"
+#include <limits.h> /* INT_MAX */
+
+static bool handle_simple_menu_key(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_KeyboardEvent *e);
+static bool handle_simple_menu_textin(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_TextInputEvent *e);
+static void render_simple_menu(struct sdlpui_dialog *d,
+        struct sdlpui_window *w);
+static void goto_simple_menu_first_control(struct sdlpui_dialog *d,
+        struct sdlpui_window *w);
+static void step_simple_menu_control(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, struct sdlpui_control *c,
+        bool forward);
+static struct sdlpui_control *find_simple_menu_control_containing(
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        Sint32 x, Sint32 y, int *comp_ind);
+static struct sdlpui_dialog *get_simple_menu_parent(struct sdlpui_dialog *d);
+static struct sdlpui_dialog *get_simple_menu_child(struct sdlpui_dialog *d);
+static struct sdlpui_control *get_simple_menu_parent_ctrl(
+        struct sdlpui_dialog *d);
+static void set_simple_menu_child(struct sdlpui_dialog *d,
+        struct sdlpui_dialog *child);
+static void resize_simple_menu(struct sdlpui_dialog *d, struct sdlpui_window *w,
+        int width, int height);
+static void query_simple_menu_natural_size(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int *width, int *height);
+static void query_simple_menu_minimum_size(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int *width, int *height);
+static void cleanup_simple_menu(struct sdlpui_dialog *d);
+
+static void render_simple_info(struct sdlpui_dialog *d,
+        struct sdlpui_window *w);
+static void goto_simple_info_first_control(struct sdlpui_dialog *d,
+        struct sdlpui_window *w);
+static struct sdlpui_control *find_simple_info_control_containing(
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        Sint32 x, Sint32 y, int *comp_ind);
+static void resize_simple_info(struct sdlpui_dialog *d, struct sdlpui_window *w,
+        int width, int height);
+static void query_simple_info_natural_size(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int *width, int *height);
+static void cleanup_simple_info(struct sdlpui_dialog *d);
+
+Uint32 SDLPUI_DIALOG_SIMPLE_MENU = 0;
+Uint32 SDLPUI_DIALOG_SIMPLE_INFO = 0;
+
+static const struct sdlpui_dialog_funcs simple_menu_funcs = {
+    handle_simple_menu_key,
+    handle_simple_menu_textin,
+    sdlpui_dialog_handle_textedit,
+    sdlpui_menu_handle_mouseclick,
+    sdlpui_dialog_handle_mousemove,
+    sdlpui_dialog_handle_mousewheel,
+    sdlpui_menu_handle_loses_mouse,
+    sdlpui_menu_handle_loses_key,
+    sdlpui_menu_handle_window_loses_mouse,
+    sdlpui_menu_handle_window_loses_key,
+    render_simple_menu,
+    NULL,
+    goto_simple_menu_first_control,
+    step_simple_menu_control,
+    find_simple_menu_control_containing,
+    get_simple_menu_parent,
+    get_simple_menu_child,
+    get_simple_menu_parent_ctrl,
+    set_simple_menu_child,
+    resize_simple_menu,
+    query_simple_menu_natural_size,
+    query_simple_menu_minimum_size,
+    cleanup_simple_menu
+};
+
+static const struct sdlpui_dialog_funcs simple_info_funcs = {
+    sdlpui_dialog_handle_key,
+    sdlpui_dialog_handle_textin,
+    sdlpui_dialog_handle_textedit,
+    sdlpui_dialog_handle_mouseclick,
+    sdlpui_dialog_handle_mousemove,
+    sdlpui_dialog_handle_mousewheel,
+    sdlpui_dialog_handle_loses_mouse,
+    sdlpui_dialog_handle_loses_key,
+    sdlpui_dialog_handle_window_loses_mouse,
+    sdlpui_dialog_handle_window_loses_key,
+    render_simple_info,
+    sdlpui_dismiss_dialog,
+    goto_simple_info_first_control,
+    NULL,
+    find_simple_info_control_containing,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    resize_simple_info,
+    query_simple_info_natural_size,
+    NULL,
+    cleanup_simple_info
+};
+
+
+/*
+ * Menus react to some additional keyboard events since the geometry allows
+ * for easy interpretations of cursor movements.  Otherwise, they act like
+ * simple dialogs.
+ */
+static bool handle_simple_menu_key(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_KeyboardEvent *e)
+{
+    /*
+     * Swap which keys do what depending on the orientation of the menu.
+     * fwd_alt1, fwd_alt2, fwd_alt3 are for the keys corresponding to
+     * the in-game east (for vertical menus) or south (for horizontal
+     * menus) motion commands from either keyset.
+     */
+    struct k_dirsyms {
+        SDL_Keycode fwd, fwd_alt1, fwd_alt2, fwd_alt3, bck, nxt, prv;
+    };
+    static const struct k_dirsyms vsyms = {
+        SDLK_RIGHT,
+        SDLK_6,
+        SDLK_KP_6,
+        SDLK_l,
+        SDLK_LEFT,
+        SDLK_DOWN,
+        SDLK_UP
+    };
+    static const struct k_dirsyms hsyms = {
+        SDLK_DOWN,
+        SDLK_2,
+        SDLK_KP_2,
+        SDLK_j,
+        SDLK_UP,
+        SDLK_RIGHT,
+        SDLK_LEFT
+    };
+    const struct k_dirsyms *csyms;
+    /*
+     * Most of the additional event handling is as a proxy for the menu's
+     * control with keyboard focus so remember what that is.
+     */
+    struct sdlpui_control *c = d->c_key;
+    struct sdlpui_simple_menu *p;
+    SDL_Keymod mods;
+
+    /* Relay to the control with focus.  if it handles it we're done. */
+    if (c && c->ftb->handle_key && (*c->ftb->handle_key)(c, d, w, e)) {
+        return true;
+    }
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+    p = d->priv;
+    csyms = (p->vertical) ? &vsyms : &hsyms;
+
+    mods = sdlpui_get_interesting_keymods();
+    if (e->keysym.sym == csyms->fwd) {
+        /*
+         * Invoke the default action for a menu entry which will
+         * descend deeper into the menu hierarchy if that entry leads
+         * to a submenu.  If there's no entry with keyboard focus,
+         * give focus to the first active entry.
+         */
+        if (c) {
+            if (e->state == SDL_PRESSED) {
+                if (mods == KMOD_NONE) {
+                    (*c->ftb->arm)(c, d, w,
+                        SDLPUI_ACTION_HINT_KEY);
+                }
+            } else {
+                /*
+                 * Always disarm, regardless of the modifier
+                 * state, in case the modifier keys changed
+                 * between the press and release.
+                 */
+                if (c->ftb->disarm) {
+                    (*c->ftb->disarm)(c, d, w,
+                        SDLPUI_ACTION_HINT_KEY);
+                }
+                if (mods == KMOD_NONE
+                        && c->ftb->respond_default) {
+                    SDLPUI_EVENT_TRACER("control", c,
+                        "(not extracted)",
+                        "invoking default response");
+                    (*c->ftb->respond_default)(c, d, w,
+                        SDLPUI_ACTION_HINT_KEY);
+                }
+            }
+        } else if (e->state == SDL_RELEASED
+                && d->ftb->goto_first_control) {
+            (*d->ftb->goto_first_control)(d, w);
+        }
+        return true;
+    }
+
+    if (e->keysym.sym == csyms->fwd_alt1 || e->keysym.sym == csyms->fwd_alt2
+            || e->keysym.sym == csyms->fwd_alt3) {
+        /*
+         * Like fwd, but as these symbols also trigger the text input
+         * handler, just handle arming and disarming of the menu
+         * button here.
+         */
+        if (c) {
+            if (e->state == SDL_PRESSED) {
+                if (mods == KMOD_NONE && c->ftb->arm) {
+                    (*c->ftb->arm)(c, d, w,
+                        SDLPUI_ACTION_HINT_KEY);
+                }
+            } else {
+                /*
+                 * Always disarm, regardless of the modifier
+                 * state, in case the modifier keys changed
+                 * between the press and release.
+                 */
+                if (c->ftb->disarm) {
+                    (*c->ftb->disarm)(c, d, w,
+                        SDLPUI_ACTION_HINT_KEY);
+                }
+            }
+        }
+        return true;
+    }
+
+    if (e->keysym.sym == csyms->bck) {
+        /*
+         * Back out to the previous level of the menu hierarchy, if any.
+         */
+        if (e->state == SDL_RELEASED && mods == KMOD_NONE) {
+            sdlpui_dialog_give_key_focus_to_parent(d, w);
+        }
+        return true;
+    }
+
+    if (e->keysym.sym == csyms->nxt) {
+        /*
+         * Go to the next active button in the menu or wrap around to
+         * the first active button in the menu if already at the end.
+         * If the menu doesn't already have key focus, give it key
+         * focus and go to the first active button.
+         */
+        if (e->state == SDL_RELEASED && mods == KMOD_NONE) {
+            if (c) {
+                if (d->ftb->step_control) {
+                    (*d->ftb->step_control)(d, w, c, true);
+                }
+            } else if (d->ftb->goto_first_control) {
+                (*d->ftb->goto_first_control)(d, w);
+            }
+        }
+        return true;
+    }
+
+    if (e->keysym.sym == csyms->prv) {
+        /*
+         * Go to the previous active button in the menu or wrap around
+         * to the first active button in the menu if already at the end.
+         * If the menu doesn't already have key focus, give it key
+         * focus and go to the first active button.
+         */
+        if (e->state == SDL_RELEASED && mods == KMOD_NONE) {
+            if (c) {
+                if (d->ftb->step_control) {
+                    (*d->ftb->step_control)(d, w, c, false);
+                }
+            } else if (d->ftb->goto_first_control) {
+                (*d->ftb->goto_first_control)(d, w);
+            }
+        }
+        return true;
+    }
+
+    return sdlpui_dialog_handle_key(d, w, e);
+}
+
+
+static bool handle_simple_menu_textin(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_TextInputEvent *e)
+{
+    /*
+     * Swap which keys do what depending on the orientation of the menu.
+     * All correspond to in-game motion commands from either keyset.
+     */
+    struct ti_dirsyms {
+        uint32_t fwd_alt1, fwd_alt2, bck_alt1, bck_alt2, nxt_alt1,
+            nxt_alt2, prv_alt1, prv_alt2;
+    };
+    static const struct ti_dirsyms vsyms = {
+        /* East descends into the menu hierarchy. */
+        '6', 'l',
+        /* West backs out. */
+        '4', 'h',
+        /* South goes to the next item in this menu. */
+        '2', 'j',
+        /* North goes to the previous item in this menu. */
+        '8', 'k'
+    };
+    static const struct ti_dirsyms hsyms = {
+        /* South descends. */
+        '2', 'j',
+        /* North backs out. */
+        '8', 'k',
+        /* East goes to the next item in this menu. */
+        '6', 'l',
+        /* West goes to the previous item in this menu. */
+        '4', 'h'
+    };
+    const struct ti_dirsyms *csyms;
+    /*
+     * Most of the additional event handling is as a proxy for the menu's
+     * control with keyboard focus so remember what that is.
+     */
+    struct sdlpui_control *c = d->c_key;
+    struct sdlpui_simple_menu *p;
+    uint32_t ch = sdlpui_utf8_to_codepoint(e->text);
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+    p = d->priv;
+    csyms = (p->vertical) ? &vsyms : &hsyms;
+
+    if (ch == csyms->fwd_alt1 || ch == csyms->fwd_alt2) {
+        /*
+         * Invoke the default action on the menu entry which will
+         * descend deeper into the menu hierarchy if the entry leads
+         * to a submenu.  If there's no menu entry with keyboard focus,
+         * give keyboard focus to the first active entry.
+         */
+        if (c) {
+            if (c->ftb->respond_default) {
+                SDLPUI_EVENT_TRACER("control", c,
+                    "(not extracted)",
+                    "invoking default response");
+                (*c->ftb->respond_default)(c, d, w,
+                    SDLPUI_ACTION_HINT_KEY);
+            }
+        } else if (d->ftb->goto_first_control) {
+            (*d->ftb->goto_first_control)(d, w);
+        }
+        return true;
+    }
+
+    if (ch == csyms->bck_alt1 || ch == csyms->bck_alt2) {
+        /*
+         * Back out to the previous level of the menu hierarchy, if any.
+         */
+        sdlpui_dialog_give_key_focus_to_parent(d, w);
+        return true;
+    }
+
+    if (ch == csyms->nxt_alt1 || ch == csyms->nxt_alt2) {
+        /*
+         * Go to the next active button in the menu or wrap around to
+         * the first active button in the menu if already at the end.
+         * If the menu doesn't already have key focus, give it key
+         * focus and go to the first active button.
+         */
+        if (c) {
+            if (d->ftb->step_control) {
+                (*d->ftb->step_control)(d, w, c, true);
+            }
+        } else if (d->ftb->goto_first_control) {
+            (*d->ftb->goto_first_control)(d, w);
+        }
+        return true;
+    }
+
+    if (ch == csyms->prv_alt1 || ch == csyms->prv_alt2) {
+        /*
+         * Got to the previous active button in the menu or wrap around
+         * to the last active button in the menu if already at the
+         * beginning.  If the menu doesn't already have key focus,
+         * give it key focus and go to the first active button.
+         */
+        if (c) {
+            if (d->ftb->step_control) {
+                (*d->ftb->step_control)(d, w, c, false);
+            }
+        } else if (d->ftb->goto_first_control) {
+            (*d->ftb->goto_first_control)(d, w);
+        }
+        return true;
+    }
+
+    return sdlpui_dialog_handle_textin(d, w, e);
+}
+
+
+static void render_simple_menu(struct sdlpui_dialog *d, struct sdlpui_window *w)
+{
+    struct SDL_Renderer *r = sdlpui_get_renderer(w);
+    SDL_Rect dst_r = d->rect;
+    int i = 0;
+    struct sdlpui_simple_menu *p;
+    const SDL_Color *color;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+    p = d->priv;
+    SDLPUI_RENDER_TRACER("simple menu", d, "(not extracted)", d->rect,
+        d->rect, d->texture);
+
+    SDL_SetRenderTarget(r, d->texture);
+    color = sdlpui_get_color(w, SDLPUI_COLOR_MENU_BG);
+    SDL_SetRenderDrawColor(r, color->r, color->g, color->b, color->a);
+    if (d->texture) {
+        dst_r.x = 0;
+        dst_r.y = 0;
+        SDL_RenderClear(r);
+    } else {
+        SDL_RenderFillRect(r, &dst_r);
+    }
+    while (1) {
+        if (i >= p->n_vis) {
+            break;
+        }
+        if (p->v_ctrls[i]->ftb->render) {
+            (*p->v_ctrls[i]->ftb->render)(p->v_ctrls[i], d, w, r);
+        }
+        ++i;
+    }
+    if (p->border) {
+        color = sdlpui_get_color(w, SDLPUI_COLOR_MENU_BORDER);
+
+        SDL_SetRenderDrawColor(r, color->r, color->g, color->b,
+            color->a);
+        SDL_RenderDrawRect(r, &dst_r);
+    }
+    d->dirty = false;
+}
+
+
+static void goto_simple_menu_first_control(struct sdlpui_dialog *d,
+        struct sdlpui_window *w)
+{
+    struct sdlpui_simple_menu *p;
+    int i = 0;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+    p = d->priv;
+
+    while (1) {
+        int comp_ind;
+
+        if (i >= p->n_vis) {
+            /* There's no members that can take focus. */
+            SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
+                "gains key focus");
+            if (d->c_key && d->c_key->ftb->lose_key) {
+                (*d->c_key->ftb->lose_key)(d->c_key, d, w,
+                    false);
+            }
+            d->c_key = NULL;
+            /* Anyways, still give the dialog key focus. */
+            sdlpui_dialog_gain_key_focus(w, d);
+            return;
+        }
+        comp_ind = (p->v_ctrls[i]->ftb->get_interactable_component) ?
+            (p->v_ctrls[i]->ftb->get_interactable_component)(
+                p->v_ctrls[i], true) : 0;
+        if (comp_ind) {
+            SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
+                "gains key focus");
+            SDL_assert(p->v_ctrls[i]->ftb->gain_key);
+            (*p->v_ctrls[i]->ftb->gain_key)(
+                p->v_ctrls[i], d, w, comp_ind - 1);
+            if (d->c_key && d->c_key != p->v_ctrls[i]
+                    && d->c_key->ftb->lose_key) {
+                (*d->c_key->ftb->lose_key)(d->c_key, d, w,
+                    false);
+            }
+            d->c_key = p->v_ctrls[i];
+            sdlpui_dialog_gain_key_focus(w, d);
+            return;
+        }
+        ++i;
+    }
+}
+
+
+static void step_simple_menu_control(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, struct sdlpui_control *c,
+        bool forward)
+{
+    struct sdlpui_simple_menu *p;
+    int istart, itry;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+    p = d->priv;
+    SDL_assert(c >= p->controls && c < p->controls + p->number);
+
+    if (c->ftb->step_within && (*c->ftb->step_within)(c, forward)) {
+        return;
+    }
+
+    istart = 0;
+    while (1) {
+        if (istart >= p->n_vis) {
+            /*
+             * c should be an active control in the menu, but it is
+             * not.
+             */
+            SDL_assert(0);
+            return;
+        }
+        if (c == p->v_ctrls[istart]) {
+            break;
+        }
+        ++istart;
+    }
+    itry = istart;
+    while (1) {
+        int comp_ind;
+
+        if (forward) {
+            ++itry;
+            if (itry == p->n_vis) {
+                itry = 0;
+            }
+        } else {
+            --itry;
+            if (itry == -1) {
+                itry = p->n_vis - 1;
+            }
+        }
+        if (itry == istart) {
+            /*
+             * Wrapped around without finding another control that
+             * can accept focus.
+             */
+            SDL_assert(d->c_key == c);
+            break;
+        }
+        comp_ind = (p->v_ctrls[itry]->ftb->get_interactable_component) ?
+            (*p->v_ctrls[itry]->ftb->get_interactable_component)(
+                p->v_ctrls[itry], forward) : 0;
+        if (comp_ind) {
+            if (d->c_key && d->c_key != p->v_ctrls[itry]
+                    && d->c_key->ftb->lose_key) {
+                (*d->c_key->ftb->lose_key)(d->c_key, d, w,
+                    false);
+            }
+            if (p->v_ctrls[itry]->ftb->gain_key) {
+                (*p->v_ctrls[itry]->ftb->gain_key)(
+                    p->v_ctrls[itry], d, w, comp_ind - 1);
+            }
+            d->c_key = p->v_ctrls[itry];
+            break;
+        }
+    }
+}
+
+
+static struct sdlpui_control *find_simple_menu_control_containing(
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        Sint32 x, Sint32 y, int *comp_ind)
+{
+    struct sdlpui_simple_menu *p;
+    int ilo, ihi;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+    p = d->priv;
+
+    SDL_assert(p->n_vis >= 0);
+    if (p->n_vis == 0 || !sdlpui_is_in_dialog(d, x, y)) {
+        *comp_ind = 0;
+        return NULL;
+    }
+
+    /* Make the coordinates relative to the dialog. */
+    x -= d->rect.x;
+    y -= d->rect.y;
+
+    /* Use a binary search to locate the control */
+    ilo = 0;
+    ihi = p->n_vis;
+    while (1) {
+        int imid;
+
+        if (ilo == ihi - 1) {
+            if (x < p->v_ctrls[ilo]->rect.x
+                    || x >= p->v_ctrls[ilo]->rect.x
+                        + p->v_ctrls[ilo]->rect.w
+                    || y < p->v_ctrls[ilo]->rect.y
+                    || y >= p->v_ctrls[ilo]->rect.y
+                        + p->v_ctrls[ilo]->rect.h) {
+                *comp_ind = 0;
+                return NULL;
+            }
+            if (p->v_ctrls[ilo]->ftb->get_interactable_component_at) {
+                int ind = (*p->v_ctrls[ilo]->ftb->get_interactable_component_at)(
+                    p->v_ctrls[ilo], x, y);
+
+                if (ind == 0) {
+                    *comp_ind = 0;
+                    return NULL;
+                }
+                *comp_ind = ind - 1;
+            } else if (!p->v_ctrls[ilo]->ftb->get_interactable_component
+                    || !(*p->v_ctrls[ilo]->ftb->get_interactable_component)(p->v_ctrls[ilo], true)) {
+                *comp_ind = 0;
+                return NULL;
+            } else {
+                *comp_ind = 0;
+            }
+            return p->v_ctrls[ilo];
+        }
+        imid = (ilo + ihi) / 2;
+        if (p->vertical) {
+            if (p->v_ctrls[imid]->rect.y > y) {
+                ihi = imid;
+                continue;
+            }
+            if (p->v_ctrls[imid]->rect.y + p->v_ctrls[imid]->rect.h
+                    <= y) {
+                ilo = imid;
+                continue;
+            }
+            if (x < p->v_ctrls[imid]->rect.x
+                    || x >= p->v_ctrls[imid]->rect.x
+                        + p->v_ctrls[imid]->rect.w) {
+                *comp_ind = 0;
+                return NULL;
+            }
+        } else {
+            if (p->v_ctrls[imid]->rect.x > x) {
+                ihi = imid;
+                continue;
+            }
+            if (p->v_ctrls[imid]->rect.x + p->v_ctrls[imid]->rect.w
+                    <= x) {
+                ilo = imid;
+                continue;
+            }
+            if (y < p->v_ctrls[imid]->rect.y
+                    || y >= p->v_ctrls[imid]->rect.y
+                        + p->v_ctrls[imid]->rect.h) {
+                *comp_ind = 0;
+                return NULL;
+            }
+        }
+        if (p->v_ctrls[imid]->ftb->get_interactable_component_at) {
+            int ind = (*p->v_ctrls[imid]->ftb->get_interactable_component_at)(
+                p->v_ctrls[imid], x, y);
+
+            if (ind == 0) {
+                *comp_ind = 0;
+                return NULL;
+            }
+            *comp_ind = ind - 1;
+        } else if (!p->v_ctrls[imid]->ftb->get_interactable_component
+                || !(*p->v_ctrls[imid]->ftb->get_interactable_component)(p->v_ctrls[imid], true)) {
+            *comp_ind = 0;
+            return NULL;
+        } else {
+            *comp_ind = 0;
+        }
+        return p->v_ctrls[imid];
+    }
+}
+
+
+static struct sdlpui_dialog *get_simple_menu_parent(struct sdlpui_dialog *d)
+{
+    struct sdlpui_simple_menu *p;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+    p = d->priv;
+    return p->parent;
+}
+
+
+static struct sdlpui_dialog *get_simple_menu_child(struct sdlpui_dialog *d)
+{
+    struct sdlpui_simple_menu *p;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+    p = d->priv;
+    return p->child;
+}
+
+
+static struct sdlpui_control *get_simple_menu_parent_ctrl(
+        struct sdlpui_dialog *d)
+{
+    struct sdlpui_simple_menu *p;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+    p = d->priv;
+    return p->parent_ctrl;
+}
+
+
+static void set_simple_menu_child(struct sdlpui_dialog *d,
+        struct sdlpui_dialog *child)
+{
+    struct sdlpui_simple_menu *p;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+    p = d->priv;
+    p->child = child;
+}
+
+
+/*
+ * Requires that the height (if the menu is vertical) or width (if the menu is
+ * horizontal) is at least as large as the minimum returned by
+ * query_simple_menu_minimum_size().
+ */
+static void resize_simple_menu(struct sdlpui_dialog *d, struct sdlpui_window *w,
+        int width, int height)
+{
+    struct sdlpui_simple_menu *p;
+    bool *vis;
+    int i, ivis, first_end, work;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+    p = d->priv;
+
+    /*
+     * First pass:  determine which buttons will definitely be visible
+     * and the boundary between the buttons attached to the front and
+     * the buttons attached to the end
+     */
+    vis = SDL_calloc(p->number, sizeof(*vis));
+    first_end = p->number;
+    work = 0;
+    for (i = 0; i < p->number; ++i) {
+        int cw, ch;
+
+        if (p->control_flags[i] & SDLPUI_MFLG_END_GRAVITY) {
+            if (first_end == p->number) {
+                first_end = i;
+            }
+        } else {
+            /*
+             * Fail if there's more than one boundary between
+             * the buttons with different gravities.
+             */
+            SDL_assert(first_end == p->number);
+        }
+        if ((p->control_flags[i] & SDLPUI_MFLG_CAN_HIDE)) {
+            continue;
+        }
+        vis[i] = true;
+        (*p->controls[i].ftb->query_natural_size)(&p->controls[i],
+            d, w, &cw, &ch);
+        if (p->vertical) {
+            work += ch;
+            SDL_assert(work <= height);
+        } else {
+            work += cw;
+            SDL_assert(work <= width);
+        }
+    }
+
+    /*
+     * Second pass:  make others visible up to the size imposed;
+     * give preference to those earlier in the array of controls
+     */
+    for (i = 0; i < p->number; ++i) {
+        int cw, ch;
+
+        if (!(p->control_flags[i] & SDLPUI_MFLG_CAN_HIDE)) {
+            continue;
+        }
+        (*p->controls[i].ftb->query_natural_size)(&p->controls[i],
+            d, w, &cw, &ch);
+        if (p->vertical) {
+            if (work + ch > height) {
+                break;
+            }
+            work += ch;
+        } else {
+            if (work + cw > width) {
+                break;
+            }
+            work += cw;
+        }
+        vis[i] = true;
+    }
+
+    /*
+     * Third pass:  fill in v_ctrls and assign positions to all of the
+     * visible controls that are anchored to the front of the menu.
+     */
+    work = 0;
+    ivis = 0;
+    for (i = 0; i < first_end; ++i) {
+        int cw, ch;
+
+        if (!vis[i]) {
+            continue;
+        }
+        p->v_ctrls[ivis] = &p->controls[i];
+        ++ivis;
+        (*p->controls[i].ftb->query_natural_size)(&p->controls[i],
+            d, w, &cw, &ch);
+        if (p->vertical) {
+            p->controls[i].rect.x = 0;
+            p->controls[i].rect.y = work;
+            work += ch;
+            if (p->controls[i].ftb->resize) {
+                (*p->controls[i].ftb->resize)(&p->controls[i],
+                    d, w, width, ch);
+            } else {
+                p->controls[i].rect.w = width;
+                p->controls[i].rect.h = ch;
+            }
+        } else {
+            p->controls[i].rect.x = work;
+            p->controls[i].rect.y = 0;
+            work += cw;
+            if (p->controls[i].ftb->resize) {
+                (*p->controls[i].ftb->resize)(&p->controls[i],
+                    d, w, cw, height);
+            } else {
+                p->controls[i].rect.w = cw;
+                p->controls[i].rect.h = height;
+            }
+        }
+    }
+
+    /*
+     * Fourth pass:  fill in v_ctrls for the visible controls anchored to
+     * the end of the menu.
+     */
+    for (i = first_end; i < p->number; ++i) {
+        if (!vis[i]) {
+            continue;
+        }
+        p->v_ctrls[ivis] = &p->controls[i];
+        ++ivis;
+    }
+    p->n_vis = ivis;
+
+    /*
+     * Fifth pass:  assign positions to all of the visible controls
+     * that are anchored to the end of the menu.
+     */
+    i = p->number;
+    work = (p->vertical) ? height : width;
+    while (i > first_end) {
+        int cw, ch;
+
+        --i;
+        if (!vis[i]) {
+            continue;
+        }
+        (*p->controls[i].ftb->query_natural_size)(&p->controls[i],
+            d, w, &cw, &ch);
+        if (p->vertical) {
+            work -= ch;
+            p->controls[i].rect.x = 0;
+            p->controls[i].rect.y = work;
+            if (p->controls[i].ftb->resize) {
+                (*p->controls[i].ftb->resize)(&p->controls[i],
+                    d, w, width, ch);
+            } else {
+                p->controls[i].rect.w = width;
+                p->controls[i].rect.h = ch;
+            }
+        } else {
+            work -= cw;
+            p->controls[i].rect.x = work;
+            p->controls[i].rect.y = 0;
+            if (p->controls[i].ftb->resize) {
+                (*p->controls[i].ftb->resize)(&p->controls[i],
+                    d, w, cw, height);
+            } else {
+                p->controls[i].rect.w = cw;
+                p->controls[i].rect.h = height;
+            }
+        }
+    }
+
+    SDL_free(vis);
+    d->rect.w = width;
+    d->rect.h = height;
+}
+
+
+static void query_simple_menu_natural_size(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int *width, int *height)
+{
+    struct sdlpui_simple_menu *p;
+    int i;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+    p = d->priv;
+
+    *width = 0;
+    *height = 0;
+    for (i = 0; i < p->number; ++i) {
+        int cw, ch;
+
+        SDL_assert(p->controls[i].ftb->query_natural_size);
+        (*p->controls[i].ftb->query_natural_size)(&p->controls[i], d, w,
+            &cw, &ch);
+        if (p->vertical) {
+            if (*width < cw) {
+                *width = cw;
+            }
+            *height += ch;
+        } else {
+            *width += cw;
+            if (*height < ch) {
+                *height = ch;
+            }
+        }
+    }
+}
+
+
+static void query_simple_menu_minimum_size(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int *width, int *height)
+{
+    struct sdlpui_simple_menu *p;
+    int i;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+    p = d->priv;
+
+    *width = 0;
+    *height = 0;
+    for (i = 0; i < p->number; ++i) {
+        int cw, ch;
+
+        if (p->control_flags[i] & SDLPUI_MFLG_CAN_HIDE) {
+            continue;
+        }
+        SDL_assert(p->controls[i].ftb->query_natural_size);
+        (*p->controls[i].ftb->query_natural_size)(&p->controls[i], d, w,
+            &cw, &ch);
+        if (p->vertical) {
+            if (*width < cw) {
+                *width = cw;
+            }
+            *height += ch;
+        } else {
+            *width += cw;
+            if (*height < ch) {
+                *height = ch;
+            }
+        }
+    }
+}
+
+
+static void cleanup_simple_menu(struct sdlpui_dialog *d)
+{
+    struct sdlpui_simple_menu *p;
+    int i;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU && d->priv);
+    p = d->priv;
+
+    for (i = 0; i < p->number; ++i) {
+        if (p->controls[i].ftb->cleanup) {
+            (*p->controls[i].ftb->cleanup)(&p->controls[i]);
+        }
+    }
+    SDL_free(p->controls);
+    SDL_free(p->v_ctrls);
+    SDL_free(p->control_flags);
+    SDL_free(p);
+}
+
+
+static void render_simple_info(struct sdlpui_dialog *d,
+        struct sdlpui_window *w)
+{
+    SDL_Renderer *r = sdlpui_get_renderer(w);
+    SDL_Rect dst_r = d->rect;
+    struct sdlpui_simple_info *id;
+    const SDL_Color *color;
+    int i;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO && d->priv);
+    id = d->priv;
+    SDLPUI_RENDER_TRACER("simple info", d, "(not extracted)", d->rect,
+        d->rect, d->texture);
+
+    SDL_SetRenderTarget(r, d->texture);
+    color = sdlpui_get_color(w, SDLPUI_COLOR_DIALOG_BG);
+    SDL_SetRenderDrawColor(r, color->r, color->g, color->b, color->a);
+    if (d->texture) {
+        SDL_RenderClear(r);
+        dst_r.x = 0;
+        dst_r.y = 0;
+    } else {
+        SDL_RenderFillRect(r, &dst_r);
+    }
+    for (i = 0; i < id->number; ++i) {
+        if (id->labels[i].ftb->render) {
+            (*id->labels[i].ftb->render)(&id->labels[i], d, w, r);
+        }
+    }
+    if (id->button.ftb->render) {
+        (*id->button.ftb->render)(&id->button, d, w, r);
+    }
+    /* Give it a border. */
+    color = sdlpui_get_color(w, SDLPUI_COLOR_DIALOG_BORDER);
+    SDL_RenderDrawRect(r, &dst_r);
+    color = sdlpui_get_color(w, SDLPUI_COLOR_COUNTERSINK);
+    ++dst_r.x;
+    ++dst_r.y;
+    dst_r.w -= 2;
+    dst_r.h -= 2;
+    SDL_RenderDrawRect(r, &dst_r);
+    d->dirty = false;
+}
+
+
+static void goto_simple_info_first_control(struct sdlpui_dialog *d,
+        struct sdlpui_window *w)
+{
+    struct sdlpui_simple_info *id;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO && d->priv);
+    id = d->priv;
+
+    SDL_assert(id->button.ftb->gain_key);
+    (*id->button.ftb->gain_key)(&id->button, d, w, 0);
+    SDL_assert(!d->c_key || d->c_key == &id->button);
+    d->c_key = &id->button;
+    sdlpui_dialog_gain_key_focus(w, d);
+}
+
+
+static struct sdlpui_control *find_simple_info_control_containing(
+        struct sdlpui_dialog *d, struct sdlpui_window *w,
+        Sint32 x, Sint32 y, int *comp_ind)
+{
+    struct sdlpui_simple_info *id;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO && d->priv);
+    id = d->priv;
+
+    *comp_ind = 0;
+    return (sdlpui_is_in_control(&id->button, d, x, y)) ?
+        &id->button : NULL;
+}
+
+
+static void resize_simple_info(struct sdlpui_dialog *d, struct sdlpui_window *w,
+        int width, int height)
+{
+    struct sdlpui_simple_info *psi;
+    int i, y, ch, cw;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO);
+    psi = (struct sdlpui_simple_info*)d->priv;
+#if NDEBUG
+    {
+        int dw, dh;
+
+        query_simple_info_natural_size(d, w, &dw, &dh);
+        SDL_assert(width >= dw && height >= dh);
+    }
+#endif
+
+    y = 0;
+    for (i = 0; i < psi->number; ++i) {
+        (*psi->labels[i].ftb->query_natural_size)(&psi->labels[i],
+            d, w, &cw, &ch);
+        if (psi->labels[i].ftb->resize) {
+            (*psi->labels[i].ftb->resize)(&psi->labels[i], d, w,
+                width, ch);
+        } else {
+            psi->labels[i].rect.w = width;
+            psi->labels[i].rect.h = ch;
+        }
+        psi->labels[i].rect.x = 0;
+        psi->labels[i].rect.y = y;
+        y += ch;
+    }
+    (*psi->button.ftb->query_natural_size)(&psi->button, d, w, &cw, &ch);
+    if (psi->button.ftb->resize) {
+        (*psi->button.ftb->resize)(&psi->button, d, w, cw, ch);
+    } else {
+        psi->button.rect.w = cw;
+        psi->button.rect.h = ch;
+    }
+    SDL_assert(width >= cw);
+    psi->button.rect.x = (width - cw) / 2;
+    SDL_assert(y < height - ch);
+    psi->button.rect.y = height - ch;
+    d->rect.w = width;
+    d->rect.h = height;
+}
+
+
+static void query_simple_info_natural_size(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int *width, int *height)
+{
+    int dw = 0, dh = 0, cw, ch, i;
+    struct sdlpui_simple_info *psi;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO);
+    psi = (struct sdlpui_simple_info*)d->priv;
+    for (i = 0; i < psi->number; ++i) {
+        (*psi->labels[i].ftb->query_natural_size)(&psi->labels[i],
+            d, w, &cw, &ch);
+        dw = (dw >= cw) ? dw : cw;
+        dh += ch;
+    }
+    (*psi->button.ftb->query_natural_size)(&psi->button, d, w, &cw, &ch);
+    dw = (dw >= cw) ? dw : cw;
+    /* Leave space between the labels and the button. */
+    dh += ch + ch;
+    *width = dw;
+    *height = dh;
+}
+
+
+static void cleanup_simple_info(struct sdlpui_dialog *d)
+{
+    struct sdlpui_simple_info *id;
+    int i;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO && d->priv);
+    id = d->priv;
+
+    for (i = 0; i < id->number; ++i) {
+        if (id->labels[i].ftb->cleanup) {
+            (*id->labels[i].ftb->cleanup)(&id->labels[i]);
+        }
+    }
+    SDL_free(id->labels);
+    SDL_free(id);
+}
+
+
+/**
+ * Determine if a given coordinate, relative to the window, is in a dialog.
+ *
+ * \param d is the dialog of interest.
+ * \param x is the horizontal coordinate, relative to the window's upper left
+ * corner, to test.
+ * \param y is the vertical coordinate, relative to the window's upper left
+ * corner, to test.
+ * \return true if (x, y) is in the control and false otherwise.
+ */
+bool sdlpui_is_in_dialog(const struct sdlpui_dialog *d, Sint32 x, Sint32 y)
+{
+    if (x < d->rect.x || y < d->rect.y || x >= d->rect.x + d->rect.w
+            || y >= d->rect.y + d->rect.h) {
+        return false;
+    }
+    return true;
+}
+
+
+/**
+ * Pop up a dialog.
+ *
+ * \param d is the dialog of interest.
+ * \param w is the window containing the dialog.
+ * \param give_key_focus, if true, causes the dialog to be given key focus
+ * when it is popped up.
+ */
+void sdlpui_popup_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
+        bool give_key_focus)
+{
+    /* Assume it may have been obscured and needs to be redrawn. */
+    d->dirty = true;
+    sdlpui_dialog_push_to_top(w, d);
+    if (give_key_focus) {
+        sdlpui_dialog_gain_key_focus(w, d);
+    }
+}
+
+
+/**
+ * Remove the dialog, any of its child dialogs, and, if all_parents is true,
+ * any of its parents up to the first parent that is pinned.
+ *
+ * \param d is the dialog to remove.
+ * \param w is the window containing the dialog.
+ * \param all_parents will cause all of the parents, up to the first parent
+ * that is pinned, if true.
+ */
+void sdlpui_popdown_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
+        bool all_parents)
+{
+    struct sdlpui_dialog *stopping_point = (all_parents) ?
+        NULL : sdlpui_get_dialog_parent(d);
+
+    while (1) {
+        struct sdlpui_dialog *child = sdlpui_get_dialog_child(d);
+
+        if (!child) {
+            break;
+        }
+        d = child;
+    }
+
+    while (1) {
+        struct sdlpui_dialog *parent = sdlpui_get_dialog_parent(d);
+        struct sdlpui_control *parent_ctrl =
+            sdlpui_get_dialog_parent_ctrl(d);
+
+        if (d->pop_callback) {
+            (*d->pop_callback)(d, w, false);
+        }
+        sdlpui_dialog_pop(w, d);
+        if (parent_ctrl && parent_ctrl->ftb->lose_child) {
+            (*parent_ctrl->ftb->lose_child)(parent_ctrl, d);
+        }
+        if (parent) {
+            SDL_assert(parent->ftb->set_child);
+            (*parent->ftb->set_child)(parent, NULL);
+
+            /*
+             * If the parent control has key focus but not mouse
+             * focus, lose that focus when the child is lost.
+             */
+            if (parent_ctrl && parent->c_key == parent_ctrl
+                    && parent->c_mouse != parent_ctrl
+                    && parent_ctrl->ftb->lose_key) {
+                (*parent_ctrl->ftb->lose_key)(parent_ctrl,
+                    parent, w, false);
+            }
+        }
+        if (d->ftb->cleanup) {
+            (*d->ftb->cleanup)(d);
+        }
+        SDL_free(d);
+
+        if (parent == stopping_point || (parent && parent->pinned)) {
+            break;
+        }
+        d = parent;
+    }
+}
+
+
+/**
+ * Give the keyboard focus for a dialog or menu to its parent.  If there is no
+ * parent and the dialog is not pinned, acts like sdlpui_popdown_dialog(d, w,
+ * false).
+ *
+ * \param d is the dialog that's ceding focus.
+ * \param w is the window containing the dialog.
+ */
+void sdlpui_dialog_give_key_focus_to_parent(struct sdlpui_dialog *d,
+        struct sdlpui_window *w)
+{
+    struct sdlpui_dialog *parent = sdlpui_get_dialog_parent(d);
+
+    if (parent) {
+        if (d->c_key != NULL && d->c_key->ftb->lose_key) {
+            (*d->c_key->ftb->lose_key)(d->c_key, d, w, false);
+        }
+        d->c_key = NULL;
+        SDLPUI_EVENT_TRACER("dialog", d,
+            "(not extracted)", "yields key focus");
+        sdlpui_dialog_yield_key_focus(w, d);
+        SDLPUI_EVENT_TRACER("dialog", parent,
+            "(not extracted)", "gains key focus");
+        sdlpui_dialog_gain_key_focus(w, parent);
+    } else {
+        SDLPUI_EVENT_TRACER("dialog", d,
+            "(not extracted)", "yields key focus");
+        sdlpui_dialog_yield_key_focus(w, d);
+        if (!d->pinned) {
+            SDLPUI_EVENT_TRACER("dialog", d,
+                "(not extracted)", "popping down");
+            sdlpui_popdown_dialog(d, w, false);
+        }
+    }
+}
+
+
+/**
+ * For a nested menu/dialog, return its parent.
+ *
+ * \param d is the dialog to query.
+ * \return the parent.  That will be NULL if the menu/dialog does not have
+ * a parent.
+ */
+struct sdlpui_dialog *sdlpui_get_dialog_parent(struct sdlpui_dialog *d)
+{
+    return (d->ftb->get_parent) ? (*d->ftb->get_parent)(d) : NULL;
+}
+
+
+/**
+ * For a nested menu/dialog, return its child.
+ *
+ * \param d is the dialog to query.
+ * \return the child.  That will be NULL if the menu/dialog does not have
+ * a child.
+ */
+struct sdlpui_dialog *sdlpui_get_dialog_child(struct sdlpui_dialog *d)
+{
+    return (d->ftb->get_child) ? (*d->ftb->get_child)(d) : NULL;
+}
+
+
+/**
+ * For a nested menu/dialog, return its parent control.
+ *
+ * \param d is the dialog to query.
+ * \return the parent control for the dialog.  That will be NULL if the
+ * menu/dialog is not a nested menu.
+ */
+struct sdlpui_control *sdlpui_get_dialog_parent_ctrl(struct sdlpui_dialog *d)
+{
+    return (d->ftb->get_parent_ctrl) ? (*d->ftb->get_parent_ctrl)(d) : NULL;
+}
+
+
+/**
+ * Perform basic handling of a keyboard event for a dialog or menu.
+ *
+ * \param d is the dialog or menu.
+ * \param w is the window containing the dialog or menu.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the window; otherwise return false.
+ */
+bool sdlpui_dialog_handle_key(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_KeyboardEvent *e)
+{
+    SDL_Keymod mods;
+
+    /* Relay to the control with focus.  If it handles it, we are done. */
+    if (d->c_key && d->c_key->ftb->handle_key
+            && (*d->c_key->ftb->handle_key)(d->c_key, d, w, e)) {
+        return true;
+    }
+
+    mods = sdlpui_get_interesting_keymods();
+    switch (e->keysym.sym) {
+    case SDLK_ESCAPE:
+        if (e->state == SDL_RELEASED && mods == KMOD_NONE) {
+            while (1) {
+                struct sdlpui_dialog *child =
+                    sdlpui_get_dialog_child(d);
+
+                if (!child) {
+                    break;
+                }
+                d = child;
+            }
+            if (!d->pinned) {
+                SDLPUI_EVENT_TRACER("dialog", d,
+                    "(not extracted)", "popping down");
+                sdlpui_popdown_dialog(d, w, true);
+            }
+        }
+        break;
+
+    case SDLK_RETURN:
+        if (e->state == SDL_RELEASED && mods == KMOD_NONE
+                && d->ftb->respond_default) {
+            SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
+                "invoking default response");
+            (*d->ftb->respond_default)(d, w);
+        }
+        break;
+
+    case SDLK_TAB:
+        if (e->state == SDL_RELEASED
+                && (mods & ~(KMOD_SHIFT | KMOD_CTRL))
+                == KMOD_NONE) {
+            if (!d->c_key) {
+                if (d->ftb->goto_first_control) {
+                    (*d->ftb->goto_first_control)(d, w);
+                }
+            } else if (d->ftb->step_control) {
+                (*d->ftb->step_control)(d, w, d->c_key,
+                    (mods & (KMOD_SHIFT)) == 0);
+            }
+        }
+        break;
+    }
+
+    /* Swallow the event, even if nothing was done. */
+    return true;
+}
+
+
+/**
+ * Perform basic handling of a text input event for a dialog or menu.
+ *
+ * \param d is the dialog or menu.
+ * \param w is the window containing the dialog or menu.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the window; otherwise return false.
+ */
+bool sdlpui_dialog_handle_textin(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_TextInputEvent *e)
+{
+    /* Relay to the control with focus.  If it handles it, we are done. */
+    if (d->c_key && d->c_key->ftb->handle_textin
+            && (*d->c_key->ftb->handle_textin)(d->c_key, d, w, e)) {
+        return true;
+    }
+
+    /* Do nothing and swallow the event. */
+    return true;
+}
+
+
+/**
+ * Perform basic handling of a text editing event for a dialog or menu.
+ *
+ * \param d is the dialog or menu.
+ * \param w is the window containing the dialog or menu.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the window; otherwise return false.
+ */
+bool sdlpui_dialog_handle_textedit(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_TextEditingEvent *e)
+{
+    /* Relay to the control with focus.  If it handles it, we are done. */
+    if (d->c_key && d->c_key->ftb->handle_textedit
+            && (*d->c_key->ftb->handle_textedit)(
+                d->c_key, d, w, e)) {
+        return true;
+    }
+
+    /* Do nothing and swallow the event. */
+    return true;
+}
+
+
+/**
+ * Perform basic handling of a mouse button event for a dialog.
+ *
+ * \param d is the dialog.
+ * \param w is the window containing the dialog.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the window; otherwise return false.
+ */
+bool sdlpui_dialog_handle_mouseclick(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseButtonEvent *e)
+{
+    /* Relay to the control with focus.  If it handles it, we are done. */
+    if (d->c_mouse && d->c_mouse->ftb->handle_mouseclick
+            && (*d->c_mouse->ftb->handle_mouseclick)(
+                d->c_mouse, d, w, e)) {
+        return true;
+    }
+
+    /* Do nothing and swallow the event. */
+    return true;
+}
+
+
+/**
+ * Perform basic handling of a mouse button event for a menu.
+ *
+ * \param d is the menu.
+ * \param w is the window containing the menu.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the window; otherwise return false.
+ */
+bool sdlpui_menu_handle_mouseclick(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseButtonEvent *e)
+{
+    /* Relay to the control with focus.  If it handles it, we are done. */
+    if (d->c_mouse && d->c_mouse->ftb->handle_mouseclick
+            && (*d->c_mouse->ftb->handle_mouseclick)(
+                d->c_mouse, d, w, e)) {
+        return true;
+    }
+
+    /*
+     * Button events while the mouse is outside the menu will act as if
+     * the menu lost mouse focus to another dialog.
+     */
+    if (!sdlpui_is_in_dialog(d, e->x, e->y)) {
+        sdlpui_menu_handle_loses_mouse(d, w, NULL);
+        return true;
+    }
+
+    /* Do nothing and swallow the event. */
+    return true;
+}
+
+
+/**
+ * Perform basic handling of a mouse motion event for a menu or dialog.
+ *
+ * \param d is the menu or dialog.
+ * \param w is the window containing the menu or dialog.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the window; otherwise return false.
+ */
+bool sdlpui_dialog_handle_mousemove(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e)
+{
+    struct sdlpui_control *c_mouse, *c;
+    int comp_ind;
+
+    /* Relay to the control with focus.  If it handles it, we are done. */
+    c_mouse = d->c_mouse;
+    if (d->c_mouse && d->c_mouse->ftb->handle_mousemove
+            && (*d->c_mouse->ftb->handle_mousemove)(
+                d->c_mouse, d, w, e)) {
+        return true;
+    }
+
+    /*
+     * Ignore motion events while a mouse button is pressed (at least up
+     * to the point that the mouse leaves the window).
+     */
+    if (e->state != 0) {
+        return true;
+    }
+
+    /*
+     * Otherwise, see if the mouse has entered another control in the
+     * dialog.  If it has, give focus to that control.
+     */
+    c = (d->ftb->find_control_containing) ?
+        (*d->ftb->find_control_containing)(d, w, e->x, e->y, &comp_ind) :
+        NULL;
+    if (c) {
+        SDL_assert(!d->c_mouse);
+
+        if (c->ftb->gain_mouse) {
+            SDLPUI_EVENT_TRACER("control", c, "(not extracted)",
+                "gains mouse focus");
+            (*c->ftb->gain_mouse)(c, d, w, comp_ind);
+        }
+    }
+    d->c_mouse = c;
+    /* Have keyboard focus follow the mouse. */
+    if (d->c_key != c) {
+        if (d->c_key && d->c_key->ftb->lose_key) {
+            SDLPUI_EVENT_TRACER("control", d->c_key,
+                "(not extracted)", "loses key focus");
+            (*d->c_key->ftb->lose_key)(d->c_key, d, w,
+                c_mouse == d->c_key);
+        }
+        if (c && c->ftb->gain_key) {
+            SDLPUI_EVENT_TRACER("control", c, "(not extracted)",
+                "gains key focus");
+            (c->ftb->gain_key)(c, d, w, comp_ind);
+        }
+        d->c_key = c;
+    }
+    if (c || sdlpui_is_in_dialog(d, e->x, e->y)) {
+        SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
+            "gains mouse focus");
+        SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
+            "gains key focus");
+        sdlpui_dialog_gain_mouse_focus(w, d);
+        sdlpui_dialog_gain_key_focus(w, d);
+        return true;
+    }
+
+    /*
+     * Let the window handle the mouse motion.  For now keep focus though
+     * moving into another dialog could cause it to be lost.
+     */
+    return false;
+}
+
+
+/**
+ * Perform basic handling of a mouse wheel event for a dialog or menu.
+ *
+ * \param d is the dialog or menu.
+ * \param w is the window containing the dialog or menu.
+ * \param e is the event to handle.
+ * \return true if the event is handled and doesn't need further processing by
+ * the window; otherwise return false.
+ */
+bool sdlpui_dialog_handle_mousewheel(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseWheelEvent *e)
+{
+    /* Relay to the control with focus.  If it handles it, we're done. */
+    if (d->c_mouse && d->c_mouse->ftb->handle_mousewheel
+            && (*d->c_mouse->ftb->handle_mousewheel)(
+                d->c_mouse, d, w, e)) {
+        return true;
+    }
+
+    /* Do nothing and swallow the event. */
+    return true;
+}
+
+
+/**
+ * This is a synonym for sdlpui_popdown_dialog(d, w, false), usable as the
+ * respond_default hook for a dialog.
+ *
+ * \param d is the dialog or menu to pop down.
+ * \param w is the window containing the dialog or menu.
+ */
+void sdlpui_dismiss_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w)
+{
+    SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)",
+        "popping down dialog");
+    sdlpui_popdown_dialog(d, w, false);
+}
+
+
+/**
+ * Respond to the mouse leaving the containing window.
+ *
+ * \param d is the dialog.
+ * \param w is the window containing the dialog.
+ */
+void sdlpui_dialog_handle_window_loses_mouse(struct sdlpui_dialog *d,
+        struct sdlpui_window *w)
+{
+    if (d->c_mouse) {
+        if (d->c_mouse->ftb->disarm) {
+            (*d->c_mouse->ftb->disarm)(d->c_mouse, d, w,
+                SDLPUI_ACTION_HINT_NONE);
+        }
+        if (d->c_mouse->ftb->lose_mouse) {
+            (*d->c_mouse->ftb->lose_mouse)(d->c_mouse, d, w, NULL);
+        }
+        /* Key focus follows mouse. */
+        if (d->c_key == d->c_mouse && d->c_mouse->ftb->lose_key) {
+            (*d->c_mouse->ftb->lose_key)(d->c_mouse, d, w, true);
+        }
+    }
+    /* Key focus follows mouse. */
+    if (d->c_key && d->c_key != d->c_mouse) {
+        if (d->c_key->ftb->disarm) {
+            (*d->c_key->ftb->disarm)(d->c_key, d, w,
+                SDLPUI_ACTION_HINT_NONE);
+        }
+        if (d->c_key->ftb->lose_key) {
+            (*d->c_key->ftb->lose_key)(d->c_key, d, w, false);
+        }
+    }
+    d->c_mouse = NULL;
+    d->c_key = NULL;
+    sdlpui_dialog_yield_mouse_focus(w, d);
+    sdlpui_dialog_yield_key_focus(w, d);
+}
+
+
+/**
+ * Respond to the mouse leaving the containing window for a pulldown/popup menu.
+ *
+ * \param d is the menu.
+ * \param w is the window containing the menu.
+ */
+void sdlpui_menu_handle_window_loses_mouse(struct sdlpui_dialog *d,
+        struct sdlpui_window *w)
+{
+    struct sdlpui_dialog *deepest = d;
+
+    while (1) {
+        struct sdlpui_dialog *child = sdlpui_get_dialog_child(deepest);
+
+        if (!child) {
+            break;
+        }
+        deepest = child;
+    }
+    if (!deepest->pinned) {
+        sdlpui_popdown_dialog(deepest, w, true);
+    } else {
+        sdlpui_dialog_handle_window_loses_mouse(d, w);
+    }
+}
+
+
+/**
+ * Respond to the containing window losing key focus.
+ *
+ * \param d is the dialog.
+ * \param w is the window containing the dialog or menu.
+ */
+void sdlpui_dialog_handle_window_loses_key(struct sdlpui_dialog *d,
+        struct sdlpui_window *w)
+{
+    if (d->c_key) {
+        if (d->c_key->ftb->disarm) {
+            (*d->c_key->ftb->disarm)(d->c_key, d, w,
+                SDLPUI_ACTION_HINT_KEY);
+        }
+        if (d->c_key->ftb->lose_key) {
+            (*d->c_key->ftb->lose_key)(d->c_key, d, w, false);
+        }
+    }
+    d->c_key = NULL;
+    sdlpui_dialog_yield_key_focus(w, d);
+}
+
+
+/**
+ * Respond to the containing window losing key focus for a pulldown/popup menu.
+ *
+ * \param d is the menu.
+ * \param w is the window containing the menu.
+ */
+void sdlpui_menu_handle_window_loses_key(struct sdlpui_dialog *d,
+        struct sdlpui_window *w)
+{
+    /*
+     * Dimiss all the child dialogs up to the one which has mouse focus
+     * or has a parent control with mouse focus.  If the dialog itself
+     * is not dismissed in that process, treat it like a generic dialog
+     * when the window loses key focus.
+     */
+    struct sdlpui_dialog *deepest = d;
+
+    while (1) {
+        struct sdlpui_dialog *child = sdlpui_get_dialog_child(deepest);
+
+        if (!child) {
+            break;
+        }
+        deepest = child;
+    }
+    while (1) {
+        struct sdlpui_dialog *parent;
+        struct sdlpui_control *parent_ctrl;
+
+        parent = sdlpui_get_dialog_parent(deepest);
+        parent_ctrl = sdlpui_get_dialog_parent_ctrl(deepest);
+        if (deepest->pinned || deepest->c_mouse
+                || (parent && parent->c_mouse == parent_ctrl)) {
+            if (deepest == d) {
+                sdlpui_dialog_handle_window_loses_key(d, w);
+            }
+            break;
+        }
+        sdlpui_popdown_dialog(deepest, w, false);
+        if (!parent || deepest == d) {
+            break;
+        }
+        deepest = parent;
+    }
+}
+
+
+/**
+ * Respond to another dialog or menu taking mouse focus from this dialog.
+ *
+ * \param d is the dialog.
+ * \param w is the window containing the menu.
+ * \param e is the mouse motion event causing the other dialog to take focus.
+ * May be NULL if not available.
+ */
+void sdlpui_dialog_handle_loses_mouse(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e)
+{
+    /*
+     * Gets the same treatment as if the mouse left the window containing
+     * the dialog.
+     */
+    sdlpui_dialog_handle_window_loses_mouse(d, w);
+}
+
+
+/**
+ * Respond to another dialog or menu taking mouse focus from this pulldown/popup
+ * menu.
+ *
+ * \param d is the dialog.
+ * \param w is the window containing the menu.
+ * \param e is the mouse motion event causing the other dialog to take focus.
+ * May be NULL if not available.
+ */
+void sdlpui_menu_handle_loses_mouse(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e)
+{
+    /*
+     * The mouse left the menu.  If the mouse is not in a child menu,
+     * pop down the menu's children.  If this menu's parent control does
+     * not contain the mouse and this menu is not pinned, pop down this
+     * menu and all parents up to the first that is pinned or contains the
+     * mouse.  If not popping down this menu, behave as if it was an
+     * ordinary dialog and the mouse left the window containing it.
+     */
+    bool remains = false;
+
+    if (e) {
+        struct sdlpui_dialog *d2 = d;
+        struct sdlpui_control *c;
+
+        while (1) {
+            struct sdlpui_dialog *child =
+                sdlpui_get_dialog_child(d2);
+
+            if (!child) {
+                break;
+            }
+            if (sdlpui_is_in_dialog(child, e->x, e->y)) {
+                sdlpui_dialog_handle_window_loses_mouse(d, w);
+                return;
+            }
+            d2 = child;
+        }
+
+        d2 = sdlpui_get_dialog_parent(d);
+        c = sdlpui_get_dialog_parent_ctrl(d);
+        if (d2 && c && sdlpui_is_in_control(c, d2, e->x, e->y)) {
+            remains = true;
+        }
+    }
+
+    if (d->pinned || remains) {
+        struct sdlpui_dialog *child = sdlpui_get_dialog_child(d);
+
+        if (child && !child->pinned) {
+            SDLPUI_EVENT_TRACER("dialog", child, "(not extracted)",
+                "popping down");
+            sdlpui_popdown_dialog(child, w, false);
+        }
+        sdlpui_dialog_handle_window_loses_mouse(d, w);
+        return;
+    }
+
+    while (1) {
+        struct sdlpui_dialog *d2 = sdlpui_get_dialog_parent(d);
+
+        if (!d2 || d2->pinned
+                || (e && sdlpui_is_in_dialog(d2, e->x, e->y))) {
+            break;
+        }
+        d = d2;
+    }
+    SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)", "popping down");
+    sdlpui_popdown_dialog(d, w, false);
+}
+
+
+/**
+ * Respond to another dialog or menu taking key focus from this dialog.
+ *
+ * \param d is the dialog.
+ * \param w is the window containing the menu.
+ * \param e is the mouse motion event causing the other dialog to take focus.
+ * May be NULL if not available.
+ */
+void sdlpui_dialog_handle_loses_key(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e)
+{
+    /*
+     * Gets the same treatment as if the window containing the dialog lost
+     * key focus.
+     */
+    sdlpui_dialog_handle_window_loses_key(d, w);
+}
+
+
+/**
+ * Respond to another dialog or menu taking key focus from this popup/pulldown
+ * menu.
+ *
+ * \param d is the menu.
+ * \param w is the window containing the menu.
+ * \param e is the mouse motion event causing the other dialog to take focus.
+ * May be NULL if not available.
+ */
+void sdlpui_menu_handle_loses_key(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e)
+{
+    /*
+     * The menu lost key focus.  If the mouse is not in a child menu, pop
+     * down this menu's children.  If this menu is not pinned and the mouse
+     * is not in this menu's parent control, pop down this menu and
+     * all parents up to the first that is pinned or contains the mouse.
+     *  If not popping down this menu, behave as if it was an ordinary
+     * dialog and the mouse left the window containing it.
+     */
+    bool remains = false;
+
+    if (e) {
+        struct sdlpui_dialog *d2 = d;
+        struct sdlpui_control *c;
+
+        while (1) {
+            struct sdlpui_dialog *child =
+                sdlpui_get_dialog_child(d2);
+
+            if (!child) {
+                break;
+            }
+            if (sdlpui_is_in_dialog(child, e->x, e->y)) {
+                sdlpui_dialog_handle_window_loses_mouse(d, w);
+                return;
+            }
+            d2 = child;
+        }
+
+        d2 = sdlpui_get_dialog_parent(d);
+        c = sdlpui_get_dialog_parent_ctrl(d);
+        if (d2 && c && sdlpui_is_in_control(c, d2, e->x, e->y)) {
+            remains = true;
+        }
+    }
+
+    if (d->pinned || remains) {
+        struct sdlpui_dialog *child = sdlpui_get_dialog_child(d);
+
+        if (child && !child->pinned) {
+            SDLPUI_EVENT_TRACER("dialog", child, "(not extracted)",
+                "popping down");
+            sdlpui_popdown_dialog(child, w, false);
+        }
+        sdlpui_dialog_handle_window_loses_mouse(d, w);
+        return;
+    }
+
+    while (1) {
+        struct sdlpui_dialog *d2 = sdlpui_get_dialog_parent(d);
+
+        if (!d2 || d2->pinned
+                || (e && sdlpui_is_in_dialog(d2, e->x, e->y))) {
+            break;
+        }
+        d = d2;
+    }
+    SDLPUI_EVENT_TRACER("dialog", d, "(not extracted)", "popping down");
+    sdlpui_popdown_dialog(d, w, false);
+}
+
+
+/**
+ * Begin constructing a simple menu.
+ *
+ * \param parent is the parent menu for the menu to be created or NULL if
+ * the menu to be created is not nested.
+ * \param parent_ctrl is the control in parent which the user interacted
+ * with to create the new menu or NULL if the menu to be created does not
+ * have a parent.
+ * \param preallocated is the number of controls to allocate space for when
+ * creating the menu.  The actual number of controls added can be greater than
+ * that but that'll incur the extra work to resize the storage for the
+ * controls.
+ * \param vertical will,  if true, causes the controls in the new menu to
+ * be layed out in a single column; if false, it causes the controls to layed
+ * out in a single row.
+ * \param border will, if true, cause a border to be drawn about the menu.
+ * \return a pointer to the structure describing the menu.
+ */
+struct sdlpui_dialog *sdlpui_start_simple_menu(struct sdlpui_dialog *parent,
+        struct sdlpui_control *parent_ctrl, int preallocated,
+        bool vertical, bool border, void (*pop_callback)(
+            struct sdlpui_dialog *d, struct sdlpui_window *w,
+            bool up), int tag)
+{
+    struct sdlpui_dialog *result = SDL_malloc(sizeof(*result));
+    struct sdlpui_simple_menu *psm = SDL_malloc(sizeof(*psm));
+
+    psm->parent = parent;
+    psm->child = NULL;
+    psm->parent_ctrl = parent_ctrl;
+    if (preallocated > 0) {
+        psm->size = preallocated;
+        psm->controls = SDL_malloc(psm->size * sizeof(*psm->controls));
+        psm->v_ctrls = SDL_malloc(psm->size * sizeof(*psm->v_ctrls));
+        psm->control_flags = SDL_malloc(psm->size
+            * sizeof(*psm->control_flags));
+    } else {
+        psm->size = 0;
+        psm->controls = NULL;
+        psm->v_ctrls = NULL;
+        psm->control_flags = NULL;
+    }
+    psm->number = 0;
+    psm->n_vis = 0;
+    psm->vertical = vertical;
+    psm->border = border;
+
+    result->ftb = &simple_menu_funcs;
+    result->pop_callback = pop_callback;
+    result->next = NULL;
+    result->prev = NULL;
+    result->texture = NULL;
+    result->c_mouse = NULL;
+    result->c_key = NULL;
+    result->priv = psm;
+    result->type_code = SDLPUI_DIALOG_SIMPLE_MENU;
+    result->tag = tag;
+    result->pinned = false;
+    result->dirty = true;
+
+    return result;
+}
+
+
+/**
+ * Get the space for the next control to be added to a simple menu.
+ * \param d is the menu to add the control to.  d must be the result of a
+ * sdlpui_start_simple_menu() and has not had sdlpui_complete_simple_menu()
+ * called for it.
+ * \param flags controls how the menu handles the new control.  It can be
+ * bitwise-or of one or more of the following:
+ *     SDLPUI_MFLG_NONE:  if no other bit is set, the new control has the
+ *         default behavior.  It is positioned from the top edge (if the menu
+ *         is vertical) or left edge (if the menu is horizontal):  with the
+ *         controls added before it being placed between that edge and the
+ *         new control.  The new control will also always be visible, provided
+ *         that the menu has space for it.
+ *    SDLPUI_MFLG_END_GRAVITY:  if this bit is set, the new control is
+ *         positioned from the bottom edge (if the menu is vertical) or
+ *         right edge (if the menu is vertical):  with the controls added
+ *         after if being placed between that edge and the new control.  All
+ *         the controls after it must also have the SDLPUI_MFLG_END_GRAVITY
+ *         bit set when they are created.
+ *    SDLPUI_MFLG_CAN_HIDE:  if this bit is set and the menu is not large
+ *         enough to display all of its controls, the menu may hide this
+ *         control so there's enough space to display the controls that do
+ *         not have the SDLPUI_MFLG_CAN_HIDE bit set.  When there are
+ *         multiple controls with the SDLPUI_MFLG_CAN_HIDE bit set, the ones
+ *         that are added later will be the ones that are hidden first.
+ * \return a pointer to the space for the new control.
+ */
+struct sdlpui_control* sdlpui_get_simple_menu_next_unused(
+        struct sdlpui_dialog *d, int flags)
+{
+    struct sdlpui_simple_menu *psm;
+    int n;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_MENU);
+    psm = (struct sdlpui_simple_menu*)d->priv;
+    SDL_assert(psm->number >= 0 && psm->number <= psm->size);
+    if (psm->number == psm->size) {
+        if (psm->size > INT_MAX / 2) {
+            SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+                "Too many menu entries");
+            sdlpui_force_quit();
+        }
+        psm->size = (psm->size) ? psm->size + psm->size : 8;
+        psm->controls = SDL_realloc(psm->controls,
+            psm->size * sizeof(*psm->controls));
+        psm->v_ctrls = SDL_realloc(psm->v_ctrls,
+            psm->size * sizeof(*psm->v_ctrls));
+        psm->control_flags = SDL_realloc(psm->control_flags,
+            psm->size * sizeof(*psm->control_flags));
+    }
+    n = psm->number;
+    ++psm->number;
+    SDL_memset(psm->controls + n, 0, sizeof(*psm->controls));
+    psm->control_flags[n] = flags;
+    return psm->controls + n;
+}
+
+
+/**
+ * Complete the construction of a simple menu.
+ *
+ * \param d is the menu of interest.
+ * \param w is the window containing the menu.
+ *
+ * Once this function is called for a menu, sdlpui_start_simple_menu() and
+ * sdlpui_get_simple_menu_next_unused() must not be called for that menu.
+ */
+void sdlpui_complete_simple_menu(struct sdlpui_dialog *d,
+        struct sdlpui_window *w)
+{
+    int dw, dh;
+
+    (*d->ftb->query_natural_size)(d, w, &dw, &dh);
+    if (d->ftb->resize) {
+        (*d->ftb->resize)(d, w, dw, dh);
+    } else {
+        d->rect.w = dw;
+        d->rect.h = dh;
+    }
+}
+
+
+/**
+ * Begin constructing a simple information dialog.
+ *
+ * \param button_label is the text label to use for the button that dismisses
+ * the dialog.
+ * \return a pointer to the structure describing the dialog.
+ */
+struct sdlpui_dialog *sdlpui_start_simple_info(const char *button_label,
+        void (*pop_callback)(struct sdlpui_dialog *d,
+            struct sdlpui_window *w, bool up), int tag)
+{
+    struct sdlpui_dialog *result = SDL_malloc(sizeof(*result));
+    struct sdlpui_simple_info *psi = SDL_malloc(sizeof(*psi));
+
+    psi->labels = NULL;
+    sdlpui_create_push_button(&psi->button, button_label,
+        SDLPUI_HOR_CENTER, sdlpui_invoke_dialog_default_action,
+        0, false);
+    psi->size = 0;
+    psi->number = 0;
+
+    result->ftb = &simple_info_funcs;
+    result->pop_callback = pop_callback;
+    result->next = NULL;
+    result->prev = NULL;
+    result->texture = NULL;
+    result->c_mouse = NULL;
+    result->c_key = NULL;
+    result->priv = psi;
+    result->type_code = SDLPUI_DIALOG_SIMPLE_INFO;
+    result->tag = tag;
+    result->pinned = false;
+    result->dirty = true;
+
+    return result;
+}
+
+
+/**
+ * Add an image to a simple information dialog.
+ *
+ * \param image is the texture containing the image to add.  The dialog assumes
+ * ownership of the texture and calls SDL_DestroyTexture() on it when the dialog
+ * is destroyed.
+ * \param halign specifies how to horizontally align the image within the
+ * dialog if the dialog is wider than the image.
+ * \param top_margin specifies the height, in pixels, of an empty space
+ * to leave along the top of the image.
+ * \param bottom_margin specifies the height, in pixels, of an empty space
+ * to leave along the bottom of the image.
+ * \param left_margin specifies the width, in pixels, of an empty space
+ * to leave along the left of the image.
+ * \param right_margin specifies the width, in pixels, of an empty space
+ * to leave along the left of the image.
+ *
+ * Images and labels added to the dialog are displayed from top to bottom in
+ * the dialog in the order they were added.
+ */
+void sdlpui_simple_info_add_image(struct sdlpui_dialog *d, SDL_Texture *image,
+        enum sdlpui_hor_align halign, int top_margin, int bottom_margin,
+        int left_margin, int right_margin)
+{
+    struct sdlpui_simple_info *psi;
+    int n;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO);
+    psi = (struct sdlpui_simple_info*)d->priv;
+    SDL_assert(psi->number >= 0 && psi->number <= psi->size);
+    if (psi->number == psi->size) {
+        if (psi->size > INT_MAX / 2) {
+            SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+                "Too many info dialog entries");
+            sdlpui_force_quit();
+        }
+        psi->size = (psi->size) ? psi->size + psi->size : 8;
+        psi->labels = SDL_realloc(psi->labels,
+            psi->size * sizeof(*psi->labels));
+    }
+    n = psi->number;
+    ++psi->number;
+    sdlpui_create_image(&psi->labels[n], image, halign, top_margin,
+        bottom_margin, left_margin, right_margin);
+}
+
+
+/**
+ * Add a label to a simple information dialog.
+ *
+ * \param label is the null-terminated UTF-8 string to use as the label.
+ * The contents of label are copied, so the lifetime of what's passed is
+ * independent of the lifetime of the control.
+ * \param halign specifies how to horizontally align the label within the
+ * dialog if the dialog is wider than the label.
+ *
+ * Images and labels added to the dialog are displayed from top to bottom in
+ * the dialog in the order they were added.
+ */
+void sdlpui_simple_info_add_label(struct sdlpui_dialog *d, const char *label,
+        enum sdlpui_hor_align halign)
+{
+    struct sdlpui_simple_info *psi;
+    int n;
+
+    SDL_assert(d->type_code == SDLPUI_DIALOG_SIMPLE_INFO);
+    psi = (struct sdlpui_simple_info*)d->priv;
+    SDL_assert(psi->number >= 0 && psi->number <= psi->size);
+    if (psi->number == psi->size) {
+        if (psi->size > INT_MAX / 2) {
+            SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+                "Too many info dialog entries");
+            sdlpui_force_quit();
+        }
+        psi->size = (psi->size) ? psi->size + psi->size : 8;
+        psi->labels = SDL_realloc(psi->labels,
+            psi->size * sizeof(*psi->labels));
+    }
+    n = psi->number;
+    ++psi->number;
+    sdlpui_create_label(&psi->labels[n], label, halign);
+}
+
+
+/**
+ * Complete the construction of a simple information dialog.
+ *
+ * \param d is the dialog of interest.
+ * \param w is the window containing the dialog.
+ *
+ * Once this function is called for a menu, sdlpui_start_simple_info(),
+ * sdlpui_simple_info_add_image(), and sdlpui_simple_info_add_label()
+ * must not be called for that menu.
+ */
+void sdlpui_complete_simple_info(struct sdlpui_dialog *d,
+        struct sdlpui_window *w)
+{
+    int dw, dh;
+
+    (*d->ftb->query_natural_size)(d, w, &dw, &dh);
+    if (d->ftb->resize) {
+        (*d->ftb->resize)(d, w, dw, dh);
+    } else {
+        d->rect.w = dw;
+        d->rect.h = dh;
+    }
+}

--- a/src/sdl2/pui-dlg.h
+++ b/src/sdl2/pui-dlg.h
@@ -1,0 +1,321 @@
+/**
+ * \file sdl2/pui-dlg.h
+ * \brief Declare the interface for menus and dialogs created by the primitive
+ * UI toolkit for SDL2.
+ */
+#ifndef INCLUDED_SDL2_SDLPUI_DIALOG_H
+#define INCLUDED_SDL2_SDLPUI_DIALOG_H
+
+#include "pui-ctrl.h"
+
+struct sdlpui_dialog;
+struct sdlpui_window;
+
+/*
+ * Set out predefined values for the type_code field of struct sdlpui_dialog.
+ * These are initialized by sdlpui_init().  For custom dialogs, you can get
+ * a code with sdlpui_register_code().
+ */
+extern Uint32 SDLPUI_DIALOG_SIMPLE_MENU;
+extern Uint32 SDLPUI_DIALOG_SIMPLE_INFO;
+
+/* Set out possible flags that can be set for buttons in a simple menu. */
+enum sdlpui_menu_flags {
+    SDLPUI_MFLG_NONE = 0,
+    SDLPUI_MFLG_END_GRAVITY = 1,    /* when the menu is bigger than needed
+                        for the buttons, the button
+                        prefers to have its position
+                        stack from the end of the
+                        menu */
+    SDLPUI_MFLG_CAN_HIDE = 2,    /* if the menu is smaller than its
+                        natural size, this button can
+                        be hidden */
+};
+
+/* Holds a function table to be used for a class of dialogs. */
+struct sdlpui_dialog_funcs {
+    /*
+     * Respond to events.  Return true if the event was handled and
+     * should not be passed on to another handler.  Otherwise, return false.
+     * Any can be NULL if the dialog and the controls it contains do not
+     * do anything with that type of event and want the window to handle it.
+     */
+    bool (*handle_key)(struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const SDL_KeyboardEvent *e);
+    bool (*handle_textin)(struct sdlpui_dialog *d, struct sdlpui_window *w,
+        const SDL_TextInputEvent *e);
+    bool (*handle_textedit)(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const SDL_TextEditingEvent *e);
+    bool (*handle_mouseclick)(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const SDL_MouseButtonEvent *e);
+    bool (*handle_mousemove)(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const SDL_MouseMotionEvent *e);
+    bool (*handle_mousewheel)(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const SDL_MouseWheelEvent *e);
+    /*
+     * Respond to the mouse focus being taken by another dialog.  May be
+     * NULL.
+     */
+    void (*handle_loses_mouse)(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const SDL_MouseMotionEvent *e);
+    /*
+     * Respond to the key focus being taken by another dialog.  May be NULL.
+     */
+    void (*handle_loses_key)(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const SDL_MouseMotionEvent *e);
+    /*
+     * Respond to the mouse leaving the containing window if the dialog
+     * had mouse focus when that happened.  May be NULL.
+     */
+    void (*handle_window_loses_mouse)(struct sdlpui_dialog *d,
+        struct sdlpui_window *w);
+    /*
+     * Respond to the containing window losing key focus if the dialog
+     * had key focus when that happened.  May be NULL.
+     */
+    void (*handle_window_loses_key)(struct sdlpui_dialog *d,
+        struct sdlpui_window *w);
+    /*
+     * Redraw for the current state of the dialog/menu.  Can be NULL,
+     * but then the dialog is not redrawn by standard event handling.
+     */
+    void (*render)(struct sdlpui_dialog *d, struct sdlpui_window *w);
+    /* Do the default action for a dialog or menu.  Can be NULL. */
+    void (*respond_default)(struct sdlpui_dialog *d,
+        struct sdlpui_window *w);
+    /*
+     * Go to the dialog's primary (or first) control that can accept
+     * focus and give it key focus.  May be NULL if there is nothing in the
+     * dialog that can accept focus.
+     */
+    void (*goto_first_control)(struct sdlpui_dialog *d,
+        struct sdlpui_window *w);
+    /*
+     * If forward is true, go to the dialog's next (with wrap around)
+     * control after c that can accept focus.  If forward is false, go to
+     * the dialog's previous (with wrap around) control before c that
+     * can accept focus.  May be NULL if the dialog never accepts focus
+     * (goto_first_control is NULL or never changes d->c_key from NULL and
+     * find_control_containing is NULL or always returns NULL) or if it
+     * only has one, simple, control that can accept focus.
+     */
+    void (*step_control)(struct sdlpui_dialog *d, struct sdlpui_window *w,
+        struct sdlpui_control *c, bool forward);
+    /*
+     * Find the dialog's control that's willing to accept focus and
+     * contains the given coordinate, relative to the window.  For simple
+     * controls, set *comp_ind to zero.  For compound controls, set
+     * *comp_ind to the index of the control, in the compound control, that
+     * accepts focus and holds the coordinate.  May be NULL:  then mouse
+     * motion will never cause the dialog to accept focus.
+     */
+    struct sdlpui_control *(*find_control_containing)(
+        struct sdlpui_dialog *d, struct sdlpui_window *w, Sint32 x,
+        Sint32 y, int *comp_ind);
+    /*
+     * For a nested menu, return the parent or child respectively for the
+     * menu.  May be NULL for a dialog that is not a nested menu.
+     */
+    struct sdlpui_dialog *(*get_parent)(struct sdlpui_dialog *d);
+    struct sdlpui_dialog *(*get_child)(struct sdlpui_dialog *d);
+    /*
+     * For a nested menu, get the parent control for the menu.  May be
+     * NULL for a dialog that is not a nested menu.
+     */
+    struct sdlpui_control *(*get_parent_ctrl)(struct sdlpui_dialog *d);
+    /*
+     * For a nested menu, allow changing the child menu.  May be NULL
+     * for a dialog that is not a nested menu.
+     */
+    void (*set_child)(struct sdlpui_dialog *d, struct sdlpui_dialog *child);
+    /*
+     * Resize the dialog so it has the given dimensions.  May be NULL
+     * if resizing the dialog is as simple as setting d->rect.w and
+     * d->rect.h to the desired dimensions.
+     */
+    void (*resize)(struct sdlpui_dialog *d, struct sdlpui_window *w,
+        int width, int height);
+    /* Get the natural size for the dialog.  May not be NULL. */
+    void (*query_natural_size)(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int *width, int *height);
+    /*
+     * Get the minimum size for the dialog.  May be NULL:  the caller
+     * will assume the natural size is the minimum size.
+     */
+    void (*query_minimum_size)(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, int *width, int *height);
+    /*
+     * Handle releasing resources for the private data, if any.  May
+     * be NULL to have no special cleanup done.
+     */
+    void (*cleanup)(struct sdlpui_dialog *d);
+};
+
+/* Represents a menu or dialog displayed on top of a window. */
+struct sdlpui_dialog {
+    const struct sdlpui_dialog_funcs *ftb;
+    /*
+     * Called with up set to true when popping the dialog up.  Called
+     * with up set to false when popping the dialog down.
+     */
+    void (*pop_callback)(struct sdlpui_dialog *d, struct sdlpui_window *w,
+        bool up);
+    /*
+     * Managed by the containing window so it can keep a stack of its
+     * menus and dialogs.
+     */
+    struct sdlpui_dialog *next, *prev;
+    /*
+     * Holds the rendered contents of the dialog/menu.  May be NULL to
+     * directly render to the window's backing buffer.
+     */
+    SDL_Texture *texture;
+    /*
+     * These point to the control which should receive mouse or keyboard
+     * events, respectively.  If NULL, events will be directed to the
+     * dialog itself.
+     */
+    struct sdlpui_control *c_mouse, *c_key;
+    /* Holds menu/dialog-specific data. */
+    void *priv;
+    /*
+     * Holds the position, relative to the window's upper left corner,
+     * and size of the dialog/menu.
+     */
+    SDL_Rect rect;
+    /* Allow for a check before casting priv to another type. */
+    Uint32 type_code;
+    /*
+     * Allow for different behavior for different dialogs with the same
+     * pop_callback.
+     */
+    int tag;
+    /*
+     * The dialog/menu is pinned and should not be automatically removed
+     * when popping down a child.
+     */
+    bool pinned;
+    /*
+     * Dialog/menu's texture is out-of-date with respect to the state of
+     * the dialog and should be rerendered.
+     */
+    bool dirty;
+};
+
+
+/*
+ * Holds the private data for a sdlpui_dialog used to represent a simple menu
+ * (either a standalone popup menu, a vertical menu pane that's part of a
+ * system of nested menus, or a horizontal menu bar).  The corresponding
+ * type_code value is SDLPUI_DIALOG_SIMPLE_MENU.
+ */
+struct sdlpui_simple_menu {
+    struct sdlpui_dialog *parent, *child;
+    struct sdlpui_control *parent_ctrl;
+    struct sdlpui_control *controls;
+                    /* flat array of the menu buttons */
+    struct sdlpui_control **v_ctrls;
+                    /* flat array referring to the subset
+                        of buttons that are visible */
+    int *control_flags;        /* flat array of flags
+                        (SDLPUI_MFLG_END_GRAVITY and
+                        SDLPUI_MFLG_CAN_HIDE) for each
+                        button */
+    int size, number, n_vis;    /* allocated number of buttons for
+                        controls, a_ctrls, and
+                        control_flags; the number of
+                        buttons in controls and
+                        control_flags; the number of
+                        buttons in v_ctrls */
+    bool vertical;
+    bool border;            /* is it rendered with a border */
+};
+
+
+/*
+ * Holds the private data for a sdlpui_dialog used to a dialog with zero or
+ * more labels or images and a button that dismisses the dialog.  The
+ * corresponding type_code value is SDLPUI_DIALOG_SIMPLE_INFO.
+ */
+struct sdlpui_simple_info {
+    struct sdlpui_control *labels;    /* flat array of controls like labels
+                        or images that don't accept
+                        focus */
+    struct sdlpui_control button;    /* single button to dismiss the
+                        dialog */
+    int size, number;        /* allocated number of controls for
+                        labels; the number of
+                        controls in labels */
+};
+
+
+bool sdlpui_is_in_dialog(const struct sdlpui_dialog *d, Sint32 x, Sint32 y);
+void sdlpui_popup_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
+        bool give_key_focus);
+void sdlpui_popdown_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w,
+        bool all_parents);
+void sdlpui_dialog_give_key_focus_to_parent(struct sdlpui_dialog *d,
+        struct sdlpui_window *w);
+struct sdlpui_dialog *sdlpui_get_dialog_parent(struct sdlpui_dialog *d);
+struct sdlpui_dialog *sdlpui_get_dialog_child(struct sdlpui_dialog *d);
+struct sdlpui_control *sdlpui_get_dialog_parent_ctrl(struct sdlpui_dialog *d);
+
+/* Standard event handlers for dialogs. */
+bool sdlpui_dialog_handle_key(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_KeyboardEvent *e);
+bool sdlpui_dialog_handle_textin(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_TextInputEvent *e);
+bool sdlpui_dialog_handle_textedit(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_TextEditingEvent *e);
+bool sdlpui_dialog_handle_mouseclick(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseButtonEvent *e);
+bool sdlpui_menu_handle_mouseclick(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseButtonEvent *e);
+bool sdlpui_dialog_handle_mousemove(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+bool sdlpui_menu_handle_mousemove(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+bool sdlpui_dialog_handle_mousewheel(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseWheelEvent *e);
+void sdlpui_dismiss_dialog(struct sdlpui_dialog *d, struct sdlpui_window *w);
+void sdlpui_dialog_handle_window_loses_mouse(struct sdlpui_dialog *d,
+        struct sdlpui_window *w);
+void sdlpui_menu_handle_window_loses_mouse(struct sdlpui_dialog *d,
+        struct sdlpui_window *w);
+void sdlpui_dialog_handle_window_loses_key(struct sdlpui_dialog *d,
+        struct sdlpui_window *w);
+void sdlpui_menu_handle_window_loses_key(struct sdlpui_dialog *d,
+        struct sdlpui_window *w);
+void sdlpui_dialog_handle_loses_mouse(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+void sdlpui_menu_handle_loses_mouse(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+void sdlpui_dialog_handle_loses_key(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+void sdlpui_menu_handle_loses_key(struct sdlpui_dialog *d,
+        struct sdlpui_window *w, const struct SDL_MouseMotionEvent *e);
+
+/* Construct a simple menu */
+struct sdlpui_dialog *sdlpui_start_simple_menu(struct sdlpui_dialog *parent,
+        struct sdlpui_control *parent_ctrl, int preallocated,
+        bool vertical, bool border, void (*pop_callback)(
+            struct sdlpui_dialog *d, struct sdlpui_window *w,
+            bool up), int tag);
+struct sdlpui_control *sdlpui_get_simple_menu_next_unused(
+        struct sdlpui_dialog *d, int flags);
+void sdlpui_complete_simple_menu(struct sdlpui_dialog *d,
+        struct sdlpui_window *w);
+
+/* Construct a simple information dialog. */
+struct sdlpui_dialog *sdlpui_start_simple_info(const char *button_label,
+        void (*pop_callback)(struct sdlpui_dialog *d,
+            struct sdlpui_window *w, bool up), int tag);
+void sdlpui_simple_info_add_image(struct sdlpui_dialog *d, SDL_Texture *image,
+        enum sdlpui_hor_align halign, int top_margin, int bottom_margin,
+        int left_margin, int right_margin);
+void sdlpui_simple_info_add_label(struct sdlpui_dialog *d, const char *label,
+        enum sdlpui_hor_align halign);
+void sdlpui_complete_simple_info(struct sdlpui_dialog *d,
+        struct sdlpui_window *w);
+
+#endif /* INCLUDED_SDL2_SDLPUI_DIALOG_H */

--- a/src/sdl2/pui-misc.c
+++ b/src/sdl2/pui-misc.c
@@ -1,0 +1,464 @@
+/**
+ * \file sdl2/pui-misc.c
+ * \brief Define miscellaneous utilities for the primitive UI toolkit for SDL2.
+ *
+ * Copyright (c) 2023 Eric Branlund
+ *
+ * This work is free software; you can redistribute it and/or modify it
+ * under the terms of either:
+ *
+ * a) the GNU General Public License as published by the Free Software
+ *    Foundation, version 2, or
+ *
+ * b) the "Angband licence":
+ *    This software may be copied and distributed for educational, research,
+ *    and not for profit purposes provided that this copyright and statement
+ *    are included in all such copies.  Other copyrights may also apply.
+ */
+
+#include "pui-misc.h"
+#include "pui-ctrl.h"
+#include "pui-dlg.h"
+
+
+struct sdlpui_code {
+    char *name;
+    Uint32 code;
+};
+
+struct sdlpui_code_registry {
+    SDL_mutex* lock;
+    struct sdlpui_code *entries;
+    size_t count, alloc;
+    Uint32 serial;
+};
+
+static struct sdlpui_code_registry my_registry = { NULL, NULL, 0, 0, 0 };
+
+
+/*
+ * Initialize the resources needed by the sdlpui_*() calls.
+ *
+ * Can safely be called multiple times without an intervening sdlpui_quit().
+ * For multithreaded applications, a race condition condition is possible
+ * if sdlpui_init() can be called while a call to sdlpui_quit() is in progress.
+ * Those applications should be structured to avoid that possibility.
+ */
+int sdlpui_init(void)
+{
+#if defined(SDLPUI_TRACE_EVENTS) || defined (SDLPUI_TRACE_RENDER)
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION,
+        SDL_LOG_PRIORITY_VERBOSE);
+#endif
+
+    if (!my_registry.lock) {
+        my_registry.lock = SDL_CreateMutex();
+
+        /* Initialize predefined type codes from pui-dlg.h. */
+        SDLPUI_DIALOG_SIMPLE_MENU =
+            sdlpui_register_code("SDLPUI_DIALOG_SIMPLE_MENU");
+        SDLPUI_DIALOG_SIMPLE_INFO =
+            sdlpui_register_code("SDLPUI_DIALOG_SIMPLE_INFO");
+        if (!SDLPUI_DIALOG_SIMPLE_MENU || !SDLPUI_DIALOG_SIMPLE_INFO) {
+            sdlpui_force_quit();
+            return 1;
+        }
+
+        /* Initialize predefined type codes from pui-ctrl.h. */
+        SDLPUI_CTRL_IMAGE = sdlpui_register_code("SDLPUI_CTRL_IMAGE");
+        SDLPUI_CTRL_LABEL = sdlpui_register_code("SDLPUI_CTRL_LABEL");
+        SDLPUI_CTRL_MENU_BUTTON =
+            sdlpui_register_code("SDLPUI_CTRL_MENU_BUTTON");
+        SDLPUI_CTRL_PUSH_BUTTON =
+            sdlpui_register_code("SDLPUI_CTRL_PUSH_BUTTON");
+        if (!SDLPUI_CTRL_IMAGE || !SDLPUI_CTRL_LABEL
+                || !SDLPUI_CTRL_MENU_BUTTON
+                || !SDLPUI_CTRL_PUSH_BUTTON) {
+            sdlpui_force_quit();
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+
+/**
+ * Release the resources allocated by sdlpui_init().
+ *
+ * Can safey be called multiple times without an intervening call to.
+ * sdlpui_init().  Once called, the only sdlpui_*() calls that can be safely
+ * used are sdlpui_init() and sdlpui_quit().  For multithreaded applications,
+ * race condtitions are possible if sdlpui_init() or sdlpui_quit() can be
+ * called while a call to sdlpui_quit() is in progress.  Those applications
+ * should be structured to avoid that possibility.
+ */
+void sdlpui_quit()
+{
+    SDL_mutex *lock = my_registry.lock;
+
+    if (lock) {
+        struct sdlpui_code *entries;
+        Uint32 i, n;
+        int retn;
+
+        retn = SDL_LockMutex(lock);
+        SDL_assert(!retn);
+        entries = my_registry.entries;
+        n = my_registry.count;
+        my_registry.entries = 0;
+        my_registry.count = 0;
+        my_registry.alloc = 0;
+        my_registry.serial = 0;
+        my_registry.lock = 0;
+        retn = SDL_UnlockMutex(lock);
+        SDL_assert(!retn);
+        for (i = 0; i < n; ++i) {
+            SDL_free(entries[i].name);
+        }
+        SDL_free(entries);
+        SDL_DestroyMutex(lock);
+    } else {
+        SDL_assert(!my_registry.entries);
+        SDL_assert(!my_registry.count);
+        SDL_assert(!my_registry.alloc);
+        SDL_assert(!my_registry.serial);
+    }
+}
+
+
+Uint32 sdlpui_register_code(const char *name)
+{
+    Uint32 code = 0, ilo, ihi;
+    int unlocked;
+
+    if (!name || !my_registry.lock || SDL_LockMutex(my_registry.lock)) {
+        return code;
+    }
+
+    /* Sorted alphabetically by name so use a binary search. */
+    SDL_assert(my_registry.count <= my_registry.alloc);
+    ilo = 0;
+    ihi = my_registry.count;
+    while (1) {
+        Uint32 imid;
+        int cmp;
+
+        if (ilo == ihi) {
+            /*
+             * It is not present.  Shift entries starting with ilo
+             * up by one to create space for a new entry.
+             */
+            Uint32 i;
+
+            if (my_registry.serial == SDL_MAX_UINT32) {
+                /*
+                 * Exhausted all the serial numbers.  Give up.
+                 */
+                break;
+            }
+            if (my_registry.count == my_registry.alloc) {
+                size_t new_alloc;
+                struct sdlpui_code *new_entries;
+
+                if (my_registry.alloc == 0) {
+                    new_alloc = 8;
+                } else if (my_registry.alloc <
+                        (size_t)-1 / 2
+                        && my_registry.alloc
+                        < (size_t)-1
+                        / sizeof(struct sdlpui_code)) {
+                    new_alloc = my_registry.alloc +
+                        my_registry.alloc;
+                } else {
+                    /*
+                     * Will exceed the range of a size_t.
+                     * Give up.
+                     */
+                    break;
+                }
+                new_entries = SDL_realloc(my_registry.entries,
+                    new_alloc * sizeof(struct sdlpui_code));
+                if (!new_entries) {
+                    break;
+                }
+                my_registry.entries = new_entries;
+                my_registry.alloc = new_alloc;
+            }
+            for (i = my_registry.count; i > ilo; --i) {
+                my_registry.entries[i].name =
+                    my_registry.entries[i - 1].name;
+                my_registry.entries[i].code =
+                    my_registry.entries[i - 1].code;
+            }
+            my_registry.entries[ilo].name = SDL_strdup(name);
+            if (!my_registry.entries[ilo].name) {
+                break;
+            }
+            code = ++my_registry.serial;
+            my_registry.entries[ilo].code = code;
+            break;
+        }
+
+        imid = (ilo + ihi) / 2;
+        cmp = strcmp(my_registry.entries[imid].name, name);
+        if (cmp == 0) {
+            code = my_registry.entries[imid].code;
+            break;
+        }
+        if (cmp < 0) {
+            ilo = imid + 1;
+        } else {
+            ihi = imid;
+        }
+    }
+
+    unlocked = !SDL_UnlockMutex(my_registry.lock);
+    SDL_assert(unlocked);
+
+    return code;
+}
+
+
+/**
+ * Strip modifiers from SDL_GetModState() that are not relevant to the
+ * primitive UI toolkit.
+ *
+ * \return the modified set of keyboard modifiers.
+ *
+ * Does this also need to strip off KMOD_CAPS?
+ */
+SDL_Keymod sdlpui_get_interesting_keymods(void)
+{
+#if SDL_VERSION_ATLEAST(2, 0, 18)
+    return SDL_GetModState() & ~(KMOD_NUM | KMOD_SCROLL);
+#else
+    return SDL_GetModState() & ~(KMOD_NUM);
+#endif
+}
+
+
+/**
+ * Compute a stipple pattern for use with a given renderer.
+ *
+ * \param r is the renderer that will be used.
+ * \return the structure describing the stipple pattern.  If an error
+ * occurs, the texture element in the structure will be NULL and SDL_GetError()
+ * will describe the cause of the error.  When the stipple pattern is no
+ * longer needed, the returned texture in the structure should be released
+ * with SDL_DestroyTexture().
+ */
+struct sdlpui_stipple sdlpui_compute_stipple(SDL_Renderer *r)
+{
+    /*
+     * The dimensions must be a multiple of two:  see the loop logic
+     * below.
+     */
+    const int width = 16, height = 16;
+    struct sdlpui_stipple result = { NULL, 0, 0 };
+    SDL_Surface *s;
+    Uint32 *pixels;
+    Uint32 rmask, gmask, bmask, amask, on_pixel, off_pixel;
+    int y;
+
+    /*
+     * on_pixel is black and completely transparent.  off_pixel is gray
+     * (0x40, 0x40, 0x40) and slightly opaque.
+     */
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+    rmask = 0xff000000;
+    gmask = 0x00ff0000;
+    bmask = 0x0000ff00;
+    amask = 0x000000ff;
+    on_pixel = 0x000000ff;
+    off_pixel = 0x40404040;
+#else
+    rmask = 0x000000ff;
+    gmask = 0x0000ff00;
+    bmask = 0x00ff0000;
+    amask = 0xff000000;
+    on_pixel = 0xff000000;
+    off_pixel = 0x40404040;
+#endif
+
+    SDL_assert(!(width & 1) && !(height & 1));
+    pixels = SDL_malloc(width * height * sizeof(*pixels));
+    for (y = 0; y < height; y += 2) {
+        uint32_t *row = pixels + y * width;
+        int x;
+
+        for (x = 0; x < width; x += 2) {
+            row[x] = on_pixel;
+            row[x + 1] = off_pixel;
+            row[x + width] = off_pixel;
+            row[x + width + 1] = on_pixel;
+        }
+    }
+
+    s = SDL_CreateRGBSurfaceFrom(pixels, width, height, 32, 4 * width,
+        rmask, gmask, bmask, amask);
+    if (s) {
+        result.texture = SDL_CreateTextureFromSurface(r, s);
+        SDL_FreeSurface(s);
+        if (result.texture) {
+            result.w = width;
+            result.h = height;
+        }
+    }
+    SDL_free(pixels);
+
+    return result;
+}
+
+
+/**
+ * Stipple a rectangle.
+ *
+ * \param r is the renderer to use.
+ * \param stp points to the texture and the texture's dimensions to use for
+ * stippling.  Must not be NULL.
+ * \param dst_r points to the rectangle bounding the area to stipple.  Must not
+ * be NULL.
+ */
+void sdlpui_stipple_rect(SDL_Renderer *r, struct sdlpui_stipple *stp,
+        const SDL_Rect *dst_r)
+{
+    SDL_Rect src_r = { 0, 0, 0, 0 }, dst2_r;
+    int ylim = dst_r->y + dst_r->h, xlim = dst_r->x + dst_r->w;
+
+    if (!stp->texture) {
+        return;
+    }
+    for (dst2_r.y = dst_r->y; dst2_r.y < ylim; dst2_r.y += stp->h) {
+        dst2_r.h = (dst2_r.y + stp->h > ylim) ?
+            ylim - dst2_r.y : stp->h;
+        src_r.h = dst2_r.h;
+        for (dst2_r.x = dst_r->x; dst2_r.x < xlim; dst2_r.x += stp->w) {
+            dst2_r.w = (dst2_r.x + stp->w > xlim) ?
+                xlim - dst2_r.x : stp->w;
+            src_r.w = dst2_r.w;
+            SDL_RenderCopy(r, stp->texture, &src_r, &dst2_r);
+        }
+    }
+}
+
+
+/**
+ * Render a line of UTF-8 text in a given font and color.
+ *
+ * \param r is the renderer to use.
+ * \param font is the font to use.
+ * \param fg points to the color to use; must not be NULL.
+ * \param dst_r points to the rectangle to be affected by the rendering.
+ * Must not be NULL.
+ * \param s is the null-terminated UTF-8 string to render, must not be NULL.
+ * Note that the rendered result is always a single line, even if s contains
+ * embedded newlines.
+ */
+void sdlpui_render_utf8_line(SDL_Renderer *r, TTF_Font *font,
+        const SDL_Color *fg, const SDL_Rect *dst_r, const char *s)
+{
+    SDL_Surface *surface = TTF_RenderUTF8_Blended(font, s, *fg);
+    SDL_Texture *src_t;
+    SDL_Rect src_r;
+
+    if (!surface) {
+        SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+            "TTF_RenderUTF8_Blended() failed: %s", TTF_GetError());
+        sdlpui_force_quit();
+    }
+    src_t = SDL_CreateTextureFromSurface(r, surface);
+    if (!src_t) {
+        SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+            "SDL_CreateTextureFromSurface() failed: %s",
+            SDL_GetError());
+        sdlpui_force_quit();
+    }
+    SDL_FreeSurface(surface);
+    src_r.x = 0;
+    src_r.y = 0;
+    if (SDL_QueryTexture(src_t, NULL, NULL, &src_r.w, &src_r.h)) {
+        SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+            "SDL_QueryTexture() failed: %s", SDL_GetError());
+        sdlpui_force_quit();
+    }
+    /*
+     * Truncate rather than compress if the rendered string is bigger than
+     * the destination.
+     */
+    if (src_r.w > dst_r->w) {
+        src_r.w = dst_r->w;
+    }
+    if (src_r.h > dst_r->h) {
+        src_r.h = dst_r->h;
+    }
+    SDL_RenderCopy(r, src_t, &src_r, dst_r);
+    SDL_DestroyTexture(src_t);
+}
+
+
+/**
+ * Get the width and height of rendered UTF-8 text.
+ *
+ * \param font is the font to use for rendering.
+ * \param s is the null-terminated UTF-8 string.
+ * \param w is dereferenced and set to the width of the renderered string.
+ * \param h is dereferenced and set to the height of the renderered string.
+ */
+void sdlpui_get_utf8_metrics(TTF_Font *font, const char *s, int *w, int *h)
+{
+    if (TTF_SizeUTF8(font, s, w, h)) {
+        SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION,
+            "TTF_SizeUTF8() failed for '%s': %s", s,
+            TTF_GetError());
+        sdlpui_force_quit();
+    }
+}
+
+
+/**
+ * Return the UTF-32 encoding for the first codepoint in a UTF-8 string.
+ *
+ * \param utf8_string is the null-terminated string of interest.
+ * \return the UTF-32 encoding, in the native byte order, for the first
+ * codepoint in the string.
+ */
+uint32_t sdlpui_utf8_to_codepoint(const char *utf8_string)
+{
+        /* hex  == binary
+         * 0x00 == 00000000
+         * 0x80 == 10000000
+         * 0xc0 == 11000000
+         * 0xe0 == 11100000
+         * 0xf0 == 11110000
+         * 0xf8 == 11111000
+         * 0x3f == 00111111
+         * 0x1f == 00011111
+         * 0x0f == 00001111
+         * 0x07 == 00000111 */
+
+        uint32_t key = 0;
+
+#define IS_UTF8_INFO(mask, result) (((unsigned char) utf8_string[0] & (mask)) == (result))
+#define EXTRACT_UTF8_INFO(pos, mask, shift) (((unsigned char) utf8_string[(pos)] & (mask)) << (shift))
+        /* 6 is the number of information bits in a utf8 continuation byte (10xxxxxx) */
+        if (IS_UTF8_INFO(0x80, 0)) {
+                key = utf8_string[0];
+        } else if (IS_UTF8_INFO(0xe0, 0xc0)) {
+                key = EXTRACT_UTF8_INFO(0, 0x1f, 6)
+                        | EXTRACT_UTF8_INFO(1, 0x3f, 0);
+        } else if (IS_UTF8_INFO(0xf0, 0xe0)) {
+                key = EXTRACT_UTF8_INFO(0, 0x0f, 12)
+                        | EXTRACT_UTF8_INFO(1, 0x3f, 6)
+                        | EXTRACT_UTF8_INFO(2, 0x3f, 0);
+        } else if (IS_UTF8_INFO(0xf8, 0xf0)) {
+                key = EXTRACT_UTF8_INFO(0, 0x07, 18)
+                        | EXTRACT_UTF8_INFO(1, 0x3f, 12)
+                        | EXTRACT_UTF8_INFO(2, 0x3f, 6)
+                        | EXTRACT_UTF8_INFO(3, 0x3f, 0);
+        }
+#undef IS_UTF8_INFO
+#undef EXTRACT_UTF8_INFO
+
+        return key;
+}

--- a/src/sdl2/pui-misc.h
+++ b/src/sdl2/pui-misc.h
@@ -1,0 +1,34 @@
+/**
+ * \file sdl2/pui-misc.h
+ * \brief Declare miscellaneous utilities for the primitive UI toolkit for SDL2.
+ */
+#ifndef INCLUDED_SDL2_SDLPUI_MISC_H
+#define INCLUDED_SDL2_SDLPUI_MISC_H
+
+#include "pui-win.h"
+
+#ifdef SDLPUI_TRACE_EVENTS
+#define SDLPUI_EVENT_TRACER(type_name, address, label, event_name) SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, "%s (%p ; \"%s\") %s\n", type_name, (void*)address, label, event_name)
+#else
+#define SDLPUI_EVENT_TRACER(type_name, address, label, event_name) (void)0
+#endif
+
+#ifdef SDLPUI_TRACE_RENDER
+#define SDLPUI_RENDER_TRACER(type_name, address, label, outer_rect, inner_rect, texture) SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, "%s (%p ; \"%s\") rendering in outer bounds, (%d,%d) %d x %d, and inner bounds, (%d,%d) %d x %d, to %p\n", type_name, (void*)address, label, outer_rect.x, outer_rect.y, outer_rect.w, outer_rect.h, inner_rect.x, inner_rect.y, inner_rect.w, inner_rect.h, (void*)texture)
+#else
+#define SDLPUI_RENDER_TRACER(type_name, address, label, outer_rect, inner_rect, texture) (void)0
+#endif
+
+int sdlpui_init(void);
+void sdlpui_quit(void);
+Uint32 sdlpui_register_code(const char *name);
+SDL_Keymod sdlpui_get_interesting_keymods(void);
+struct sdlpui_stipple sdlpui_compute_stipple(SDL_Renderer *r);
+void sdlpui_stipple_rect(SDL_Renderer *r, struct sdlpui_stipple *stp,
+        const SDL_Rect *dst_r);
+void sdlpui_render_utf8_line(SDL_Renderer *r, TTF_Font *font,
+        const SDL_Color *fg, const SDL_Rect *dst_r, const char *s);
+void sdlpui_get_utf8_metrics(TTF_Font *font, const char *s, int *w, int *h);
+Uint32 sdlpui_utf8_to_codepoint(const char *uft8_string);
+
+#endif /* INCLUDED_SDL2_SDLPUI_MISC_H */

--- a/src/sdl2/pui-win.h
+++ b/src/sdl2/pui-win.h
@@ -1,0 +1,176 @@
+/**
+ * \file sdl2/pui-win.h
+ * \brief Make declarations to connect the SDL2 front end to a primitive UI
+ * toolkit based on SDL2 that will handle dialogs and menus overlayed on the
+ * front end's windows.  All functions declared here have to be implemented
+ * by the front end:  they are not implemented by the primitive UI toolkit.
+ */
+#ifndef INCLUDED_SDL2_SDLPUI_WINDOW_H
+#define INCLUDED_SDL2_SDLPUI_WINDOW_H
+
+#ifdef WINDOWS
+#include "..\_SDL2\SDL.h"
+#include "..\_SDL2\SDL_ttf.h"
+#else
+#include "SDL.h"    /* SDL_Color, SDL_Renderer, SDL_Texture */
+#include "SDL_ttf.h"    /* TTF_Font */
+#endif
+
+
+/* Forward declarations for the primitive UI toolkit implementation */
+struct sdlpui_dialog;
+
+/*
+ * Forward declaration for the application's data associated with an
+ * SDL_Window; the UI toolkit does not care about its internals
+ */
+struct sdlpui_window;
+
+struct sdlpui_stipple {
+    SDL_Texture *texture;
+    int w, h;        /* width and height */
+};
+
+
+/**
+ * Get the SDL_Renderer that the UI toolkit can use to render.
+ *
+ * \param w is the window containing what's to be rendered.
+ * \return the renderer that can be used to render directly to the window
+ * or to a texture.
+ */
+SDL_Renderer *sdlpui_get_renderer(struct sdlpui_window *w);
+
+/**
+ * Retrieve a reference to the font to use for all dialogs or menus.
+ *
+ * \param w is the window containing what's to be rendered.
+ * \return a pointer to the TTF font to use.
+ */
+TTF_Font *sdlpui_get_ttf(struct sdlpui_window *w);
+
+/**
+ * Retrieve a reference to a stipple pattern.
+ *
+ * \param w is the window containing what'll be stippled.
+ * \return a pointer to the structure describing the stippling.
+ *
+ * One can use sdlpui_compute_stipple() from sdlpui-misc.h to construct
+ * the stipple pattern.
+ */
+struct sdlpui_stipple *sdlpui_get_stipple(struct sdlpui_window *w);
+
+/*
+ * These are the roles where the primitive UI toolkit uses color.  You could
+ * either assign unique values to each (so you can lookup the appropriate
+ * color in sdlpui_get_color()) or optimize away that indirection and assign
+ * them the appopriate index for a color table that'll be directly accessed by
+ * sdlpui_get_color().
+ */
+#define SDLPUI_COLOR_MENU_BG (0)    /* background color for all menus */
+#define SDLPUI_COLOR_MENU_FG (1)    /* foreground color for all menus */
+#define SDLPUI_COLOR_MENU_BORDER (2)    /* border color for the menus that
+                        have a border */
+#define SDLPUI_COLOR_DIALOG_BG (3)    /* background color for any dialog
+                        that is not a menu */
+#define SDLPUI_COLOR_DIALOG_FG (4)    /* foreground color for any dialog
+                        that is not a menu */
+#define SDLPUI_COLOR_DIALOG_BORDER (5)    /* border color for any dialog that
+                        is not a menu */
+#define SDLPUI_COLOR_COUNTERSINK (6)    /* outer border color for push buttons
+                        in dialogs and inner boundary
+                        for dialogs that are not
+                        menus */
+
+/**
+ * Retrieve a reference to the color to use for a specific role when
+ * rendering dialogs or menus.
+ *
+ * \param w is the window containing what's to be rendered.
+ * \param role is one of the SDLPUI_COLOR_* constants referring to how the
+ * color will be used.
+ * \return a pointer to color to use.
+ */
+const SDL_Color *sdlpui_get_color(struct sdlpui_window *w, int role);
+
+/**
+ * Signal that the window needs to be redrawn to reflect the state of the
+ * dialogs and menus.
+ */
+void sdlpui_signal_redraw(struct sdlpui_window *w);
+
+/**
+ * Push the given dialog (adding it if not already present) to the top of the
+ * window's stack of dialogs.
+ *
+ * \param w is the window containing the dialog.
+ * \param d is the dialog.
+ *
+ * Should also signal a redraw of the window is necessary if the dialog is
+ * not already at the top of the dialog stack.
+ */
+void sdlpui_dialog_push_to_top(struct sdlpui_window *w,
+        struct sdlpui_dialog *d);
+
+/**
+ * Remove the given dialog from the window's stack of dialogs.
+ *
+ * \param w is the window containing the dialog.
+ * \param d is the dialog.
+ *
+ * Has the side effect of ceding mouse and keyboard focus if the dialog has
+ * them and signalling that a redraw is necessary for the window.
+ */
+void sdlpui_dialog_pop(struct sdlpui_window *w, struct sdlpui_dialog *d);
+
+/**
+ * Tell the given window that the given dialog wants to take keyboard focus
+ * and receive all keyboard, text input, or text editing events in the window
+ * until it yields keyboard focus.
+ *
+ * \param w is the window containing the dialog.
+ * \param d is the dialog that wants to gain focus.
+ */
+void sdlpui_dialog_gain_key_focus(struct sdlpui_window *w,
+        struct sdlpui_dialog *d);
+
+/**
+ * Tell the given window that the given dialog wants to give up keyboard focus
+ * and not be sent keyboard, text input, or text editing events until it
+ * reacquires keyboard focus.
+ *
+ * \param w is the window containing the dialog.
+ * \param d is the dialog that is yielding focus.
+ */
+void sdlpui_dialog_yield_key_focus(struct sdlpui_window *w,
+        struct sdlpui_dialog *d);
+
+/**
+ * Tell the given window that the given dialog wants to take mouse focus and
+ * receive all mouse button, mouse wheel, and mouse motion events in the window
+ * until it yields mouse focus.
+ *
+ * \param w is the window containing the dialog.
+ * \param d is the dialog that wants to gain focus.
+ */
+void sdlpui_dialog_gain_mouse_focus(struct sdlpui_window *w,
+        struct sdlpui_dialog *d);
+
+/**
+ * Tell the given window that the given dialog wants to give up mouse focus
+ * and not be sent mouse button or mouse wheel events until it reacquires
+ * mouse focus.  Mouse motion events may be sent to a dialog without focus to
+ * see if that event would cause it to reacquire focus.
+ *
+ * \param w is the window containing the dialog.
+ * \param d is the dialog that is yielding focus.
+ */
+void sdlpui_dialog_yield_mouse_focus(struct sdlpui_window *w,
+        struct sdlpui_dialog *d);
+
+/**
+ * Quit the application.  Expected to not return.
+ */
+void sdlpui_force_quit(void);
+
+#endif /* INCLUDED_SDL2_SDLPUI_WINDOW_H */


### PR DESCRIPTION
- Update main-sdl2.c, V Commits on Jan 9, 2024
- removed 'bool font_page', replaced by 'More' button
- new UI /src/sdl2/pui-...
- Added support resizing tiles in the game 
_'Dungeon size'_ `net_term_resize()` _(just like in V, tiles can be changed in game)_
- Added fix Hack -- `term_xtra_event()` Check if the main window is unloaded. quit_hook() free resources
this fixes 'free resources' functions bug. 
before `free_globals(&g_app);` after `textui_cleanup();`... called `term_xtra_event` 'subwindow->app'
`Net_cleanup()` -> `Term_xtra(TERM_XTRA_DELAY, 50);`
Thread 1 "pwmangclient" received signal SIGSEGV, Segmentation fault.
0x00005555555cb4f3 in term_xtra_event (v=0) at client/main-sdl2.c:4022
4022        redraw_all_windows(**subwindow->app**, true);