### PR TITLE
SDL2 client fix 'sound' buttons, cleanup network stuff

### DIFF
--- a/src/client/main-sdl2.c
+++ b/src/client/main-sdl2.c
@@ -2089,9 +2089,31 @@ static void handle_menu_sound_volume(struct sdlpui_control *ctrl,
     SDL_assert(ctrl->ftb->get_tag);
     tag = (*ctrl->ftb->get_tag)(ctrl);
     if (tag) {
-        sound_volume = mb->v.ranged_int.curr;
-    } else {
+        if (mb->v.ranged_int.curr > music_volume) {
+            mb->v.ranged_int.curr += 4;
+            if (mb->v.ranged_int.curr > 100) {
+                mb->v.ranged_int.curr = 100;
+            }
+        } else if (mb->v.ranged_int.curr < music_volume) {
+            mb->v.ranged_int.curr -= 4;
+            if (mb->v.ranged_int.curr < 0) {
+                mb->v.ranged_int.curr = 0;
+            }
+        }
         music_volume = mb->v.ranged_int.curr;
+    } else {
+        if (mb->v.ranged_int.curr > sound_volume) {
+            mb->v.ranged_int.curr += 4;
+            if (mb->v.ranged_int.curr > 100) {
+                mb->v.ranged_int.curr = 100;
+            }
+        } else if (mb->v.ranged_int.curr < sound_volume) {
+            mb->v.ranged_int.curr -= 4;
+            if (mb->v.ranged_int.curr < 0) {
+                mb->v.ranged_int.curr = 0;
+            }
+        }
+        sound_volume = mb->v.ranged_int.curr;
     }
 }
 
@@ -4028,13 +4050,6 @@ static errr term_xtra_event(int v)
 {
     struct subwindow *subwindow = Term->data;
     assert(subwindow != NULL);
-
-    /* Hack -- Check if the main window is unloaded. quit_hook() free resources */
-    if (!g_app.windows[0].loaded) {
-        /* Delay 100ms */
-        SDL_Delay(100);
-        return 0;
-    }
 
     redraw_all_windows(subwindow->app, true);
 
@@ -6064,14 +6079,6 @@ static void quit_hook(const char *s)
         dump_config_file(&g_app);
     }
 
-    free_globals(&g_app);
-    quit_systems();
-
-    /* Free resources */
-    textui_cleanup();
-    cleanup_angband();
-    close_sound();
-
     /* Cleanup network stuff */
     Net_cleanup();
 
@@ -6079,6 +6086,14 @@ static void quit_hook(const char *s)
     /* Cleanup WinSock */
     WSACleanup();
 #endif
+
+    free_globals(&g_app);
+    quit_systems();
+
+    /* Free resources */
+    textui_cleanup();
+    cleanup_angband();
+    close_sound();
 }
 
 static void init_systems(void)

--- a/src/sdl2/pui-ctrl.h
+++ b/src/sdl2/pui-ctrl.h
@@ -19,8 +19,11 @@ struct sdlpui_window;
 
 /*
  * Default width for empty space around labels, push buttons, and menu buttons
+ * Two is smallest useful value (one pixel to indicate focus; another to
+ * indicate arming).  Larger than that will leave some blank space between
+ * the caption for a control and what's drawn to indicate focus or arming.
  */
-#define SDLPUI_DEFAULT_CTRL_BORDER 8
+#define SDLPUI_DEFAULT_CTRL_BORDER 3
 
 /*
  * Set out predefined values for the type_code field of struct sdlpui_control.


### PR DESCRIPTION
- fix 'sound' buttons (-5/+5)
- SDL2: use a smaller border around controls in menus and dialogs
- fix 'cleanup network stuff' bug
```
Thread 1 "pwmangclient" received signal SIGSEGV, Segmentation fault.
0x0000000800000002 in ?? ()
(gdb) bt
#0  0x0000000800000002 in  ()
#1  0x00005555555b2b23 in Term_xtra (n=10, v=50) at client/ui-term.c:468
#2  0x0000555555582a55 in Net_cleanup () at client/netclient.c:6468

#1  0x00005555555b2b23 in Term_xtra (n=10, v=50) at client/ui-term.c:468
    /* Call the hook */
    return ((*Term->xtra_hook)(n, v));
#2  0x0000555555582a55 in Net_cleanup () at client/netclient.c:6468
    Term_xtra(TERM_XTRA_DELAY, 50);
```
_fixed:_
```
/* Cleanup network stuff */
Net_cleanup() -> Term_xtra(TERM_XTRA_DELAY, 50);
-> free_globals(&g_app); ... Free resources ...
```