### PR TITLE
fix Windows client 'alphablend', 'overdraw'

### DIFF
--- a/src/client/main-win.c
+++ b/src/client/main-win.c
@@ -2232,8 +2232,7 @@ static errr Term_pict_win(int x, int y, int n, const uint16_t *ap, const char *c
     /* Redraw the top tiles */
     for (i = 0; i < n; i++)
     {
-        if ((alphablend || overdraw) &&
-            !Term_info(x + i * tile_wid, y - tile_hgt, &a, &c, &ta, &tc))
+        if (overdraw && !Term_info(x + i * tile_wid, y - tile_hgt, &a, &c, &ta, &tc))
         {
             if (a & 0x80)
                 Term_pict_win_aux(x + i * tile_wid, y - tile_hgt, 1, &a, &c, &ta, &tc);


### PR DESCRIPTION
'alphablend' option enabled, 'overdraw' disabled
/tiles/list.txt

> extra:1:0:0

Checking 'Redraw the top tiles', for 'overdraw'
this is similar to SDL client
https://github.com/draconisPW/PWMAngband/blob/6f145ba655b8861013ff2644bcb432ce350587fa/src/client/main-sdl.c#L5871

```
Term_pict_sdl()
 /* Redraw the top tile */
if (overdraw && !Term_info(col + i * tile_wid, row - tile_hgt, &a, &c, &ta, &tc))
```