### PR TITLE
fix sdl2 map

### DIFF
--- a/src/client/main-sdl2.c
+++ b/src/client/main-sdl2.c
@@ -1089,8 +1089,11 @@ static void render_tile_rect_scaled(const struct subwindow *subwindow,
     int src_row = a & 0x7f;
     int src_col = c & 0x7f;
 
-    src.x = src_col * src.w;
-    src.y = src_row * src.h;
+    if (a & 0x80)
+    {
+        src.x = src_col * src.w;
+        src.y = src_row * src.h;
+    }
 
     if (graphics->overdraw_row != 0
             && src_row >= graphics->overdraw_row
@@ -1129,8 +1132,11 @@ static void render_tile_font_scaled(const struct subwindow *subwindow,
     int src_row = a & 0x7f;
     int src_col = c & 0x7f;
 
-    src.x = src_col * src.w;
-    src.y = src_row * src.h;
+    if (a & 0x80)
+    {
+        src.x = src_col * src.w;
+        src.y = src_row * src.h;
+    }
 
     if (graphics->overdraw_row != 0
             && row > 2
@@ -4532,9 +4538,9 @@ static void term_view_map_tile(struct subwindow *subwindow)
 
     render_clear(subwindow->window, map, &subwindow->color);
 
-    for (int y = 0; y < subwindow->rows - (ROW_MAP + 1); y++) {
+    for (int y = 0; y < Setup.max_row; y++) {
         tile.y = y * tile.w;
-        for (int x = 0; x < subwindow->cols - (COL_MAP + 1); x++) {
+        for (int x = 0; x < Setup.max_col; x++) {
             tile.x = x * tile.h;
             render_grid_cell_tile(subwindow, map, tile, x, y);
         }
@@ -4582,8 +4588,8 @@ static void term_view_map_text(struct subwindow *subwindow)
 
     render_clear(subwindow->window, map, &subwindow->color);
 
-    for (int y = 0; y < subwindow->rows - (ROW_MAP + 1); y++) {
-        for (int x = 0; x < subwindow->cols - (COL_MAP + 1); x++) {
+    for (int y = 0; y < Setup.max_row; y++) {
+        for (int x = 0; x < Setup.max_col; x++) {
             render_grid_cell_text(subwindow, map, x, y);
         }
     }


### PR DESCRIPTION
- fixed map, if font size is set to small, is similar to https://github.com/draconisPW/PWMAngband/blob/c5501ffdc4df87df5756547d57d2631b91f69fab/src/client/main-win.c#L2313-L2323
Setup.max_row, Setup.max_col for map_info(), `player->scr_info[y][x]`
```
V code:
term_view_map_tile()
int w = tile.w * cave->width;
int h = tile.h * cave->height;
. . . . .
for (int y = 0; y < cave->height; y++) {
	tile.y = y * tile.w;
	for (int x = 0; x < cave->width; x++) {
		tile.x = x * tile.h;
		render_grid_cell_tile(subwindow, map, tile, x, y);
	}
}
```

- check (a & 0x80) is similar to https://github.com/draconisPW/PWMAngband/blob/c5501ffdc4df87df5756547d57d2631b91f69fab/src/client/main-sdl.c#L5638-L5642
_fixed_
![screen2](https://github.com/draconisPW/PWMAngband/assets/71586060/d8ef0e0c-6d83-4af6-951f-3968c5841109)
